### PR TITLE
add priority

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -141,6 +141,28 @@ wiremongo.insert()
 
 The above example matches all commands that try to insert *bananas* into *fruits*. Note that the json matcher supports a flag `ignoreExtraElements` that allows these insert documents to be matched even if they contain additional fields (e.g. mass & expiration).
 
+=== Priority
+
+If several mocks are set up for the same command and matching criteria, WireMongo will use the mock with the highest priority. The default behaviour is to give mocks an increasing priority as they are added so the most recently added always has the highest priority:
+
+[source,java]
+----
+wiremongo.count().inCollection("fruits").returns(21L);
+wiremongo.count().inCollection("fruits").returns(42L);
+
+// a call to mongo.count("fruits") will return 42
+----
+
+However, priorities can be user-defined:
+
+[source,java]
+----
+wiremongo.count().inCollection("fruits").priority(13).returns(21L);
+wiremongo.count().inCollection("fruits").priority(11).returns(42L);
+
+// a call to mongo.count("fruits") will return 21
+----
+
 == Stubs
 
 Stubs are the *response* part of the mock, i.e. they define how the mock *responds* to commands that match. The most low-level stubs are *custom stubs*:

--- a/src/main/java/com/noenv/wiremongo/mapping/Aggregate.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/Aggregate.java
@@ -11,6 +11,7 @@ public class Aggregate extends WithStreamPipeline {
     public AggregateCommand(String collection, JsonArray pipeline) {
       this("aggregate", collection, pipeline);
     }
+
     public AggregateCommand(String method, String collection, JsonArray pipeline) {
       super(method, collection, pipeline);
     }
@@ -29,6 +30,12 @@ public class Aggregate extends WithStreamPipeline {
   }
 
   // fluent
+
+
+  @Override
+  public Aggregate priority(int priority) {
+    return (Aggregate) super.priority(priority);
+  }
 
   @Override
   public Aggregate inCollection(String collection) {

--- a/src/main/java/com/noenv/wiremongo/mapping/AggregateWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/AggregateWithOptions.java
@@ -60,6 +60,11 @@ public class AggregateWithOptions extends Aggregate {
   // fluent
 
   @Override
+  public AggregateWithOptions priority(int priority) {
+    return (AggregateWithOptions) super.priority(priority);
+  }
+
+  @Override
   public AggregateWithOptions inCollection(String collection) {
     return (AggregateWithOptions) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/BulkWrite.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/BulkWrite.java
@@ -45,7 +45,7 @@ public class BulkWrite extends WithCollection<MongoClientBulkWriteResult> {
   public BulkWrite(JsonObject json) {
     super(json);
     operations = Matcher.create(json.getJsonObject("operations"),
-      j -> ((JsonArray)j).stream().map(v -> new BulkOperation((JsonObject)v)).collect(Collectors.toList()),
+      j -> ((JsonArray) j).stream().map(v -> new BulkOperation((JsonObject) v)).collect(Collectors.toList()),
       l -> new JsonArray(l.stream().map(BulkOperation::toJson).collect(Collectors.toList())));
   }
 
@@ -76,6 +76,11 @@ public class BulkWrite extends WithCollection<MongoClientBulkWriteResult> {
   }
 
   // fluent
+
+  @Override
+  public BulkWrite priority(int priority) {
+    return (BulkWrite) super.priority(priority);
+  }
 
   @Override
   public BulkWrite inCollection(String collection) {

--- a/src/main/java/com/noenv/wiremongo/mapping/BulkWriteWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/BulkWriteWithOptions.java
@@ -34,7 +34,7 @@ public class BulkWriteWithOptions extends BulkWrite {
 
   public BulkWriteWithOptions(JsonObject json) {
     super(json);
-    options = Matcher.create(json.getJsonObject("options"), j -> new BulkWriteOptions((JsonObject)j), BulkWriteOptions::toJson);
+    options = Matcher.create(json.getJsonObject("options"), j -> new BulkWriteOptions((JsonObject) j), BulkWriteOptions::toJson);
   }
 
   @Override
@@ -59,6 +59,11 @@ public class BulkWriteWithOptions extends BulkWrite {
   }
 
   // fluent
+
+  @Override
+  public BulkWriteWithOptions priority(int priority) {
+    return (BulkWriteWithOptions) super.priority(priority);
+  }
 
   @Override
   public BulkWriteWithOptions inCollection(String collection) {

--- a/src/main/java/com/noenv/wiremongo/mapping/Count.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/Count.java
@@ -21,10 +21,15 @@ public class Count extends WithQuery<Long> {
 
   @Override
   protected Long parseResponse(Object jsonValue) {
-    return ((Number)jsonValue).longValue();
+    return ((Number) jsonValue).longValue();
   }
 
   // fluent
+
+  @Override
+  public Count priority(int priority) {
+    return (Count) super.priority(priority);
+  }
 
   @Override
   public Count inCollection(String collection) {
@@ -37,7 +42,7 @@ public class Count extends WithQuery<Long> {
   }
 
   @Override
-  public Count withQuery(JsonObject query){
+  public Count withQuery(JsonObject query) {
     return (Count) super.withQuery(query);
   }
 

--- a/src/main/java/com/noenv/wiremongo/mapping/CreateCollection.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/CreateCollection.java
@@ -27,6 +27,11 @@ public class CreateCollection extends WithCollection<Void> {
   // fluent
 
   @Override
+  public CreateCollection priority(int priority) {
+    return (CreateCollection) super.priority(priority);
+  }
+
+  @Override
   public CreateCollection inCollection(String collection) {
     return (CreateCollection) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/CreateIndex.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/CreateIndex.java
@@ -70,6 +70,11 @@ public class CreateIndex extends WithCollection<Void> {
   // fluent
 
   @Override
+  public CreateIndex priority(int priority) {
+    return (CreateIndex) super.priority(priority);
+  }
+
+  @Override
   public CreateIndex inCollection(String collection) {
     return (CreateIndex) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/CreateIndexWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/CreateIndexWithOptions.java
@@ -31,7 +31,7 @@ public class CreateIndexWithOptions extends CreateIndex {
 
   public CreateIndexWithOptions(JsonObject json) {
     super(json);
-    options = Matcher.create(json.getJsonObject("options"), j -> new IndexOptions((JsonObject)j), IndexOptions::toJson);
+    options = Matcher.create(json.getJsonObject("options"), j -> new IndexOptions((JsonObject) j), IndexOptions::toJson);
   }
 
   @Override
@@ -56,6 +56,11 @@ public class CreateIndexWithOptions extends CreateIndex {
   }
 
   // fluent
+
+  @Override
+  public CreateIndexWithOptions priority(int priority) {
+    return (CreateIndexWithOptions) super.priority(priority);
+  }
 
   @Override
   public CreateIndexWithOptions inCollection(String collection) {

--- a/src/main/java/com/noenv/wiremongo/mapping/Distinct.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/Distinct.java
@@ -77,6 +77,11 @@ public class Distinct extends WithCollection<JsonArray> {
   // fluent
 
   @Override
+  public Distinct priority(int priority) {
+    return (Distinct) super.priority(priority);
+  }
+
+  @Override
   public Distinct inCollection(String collection) {
     return (Distinct) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/DistinctBatch.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/DistinctBatch.java
@@ -80,6 +80,11 @@ public class DistinctBatch extends WithStream {
   // fluent
 
   @Override
+  public DistinctBatch priority(int priority) {
+    return (DistinctBatch) super.priority(priority);
+  }
+
+  @Override
   public DistinctBatch inCollection(String collection) {
     return (DistinctBatch) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/DistinctBatchWithQuery.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/DistinctBatchWithQuery.java
@@ -71,6 +71,11 @@ public class DistinctBatchWithQuery extends DistinctBatch {
   // fluent
 
   @Override
+  public DistinctBatchWithQuery priority(int priority) {
+    return (DistinctBatchWithQuery) super.priority(priority);
+  }
+
+  @Override
   public DistinctBatchWithQuery withFieldName(String fieldName) {
     return (DistinctBatchWithQuery) super.withFieldName(fieldName);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/DistinctWithQuery.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/DistinctWithQuery.java
@@ -77,6 +77,11 @@ public class DistinctWithQuery extends WithQuery<JsonArray> {
   // fluent
 
   @Override
+  public DistinctWithQuery priority(int priority) {
+    return (DistinctWithQuery) super.priority(priority);
+  }
+
+  @Override
   public DistinctWithQuery withQuery(JsonObject query) {
     return (DistinctWithQuery) super.withQuery(query);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/DropCollection.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/DropCollection.java
@@ -27,6 +27,11 @@ public class DropCollection extends WithCollection<Void> {
   // fluent
 
   @Override
+  public DropCollection priority(int priority) {
+    return (DropCollection) super.priority(priority);
+  }
+
+  @Override
   public DropCollection inCollection(String collection) {
     return (DropCollection) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/DropIndex.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/DropIndex.java
@@ -62,6 +62,11 @@ public class DropIndex extends WithCollection<Void> {
   // fluent
 
   @Override
+  public DropIndex priority(int priority) {
+    return (DropIndex) super.priority(priority);
+  }
+
+  @Override
   public DropIndex inCollection(String collection) {
     return (DropIndex) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/Find.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/Find.java
@@ -13,6 +13,7 @@ public class Find extends WithQuery<List<JsonObject>> {
     public FindCommand(String collection, JsonObject query) {
       this("find", collection, query);
     }
+
     public FindCommand(String method, String collection, JsonObject query) {
       super(method, collection, query);
     }
@@ -32,12 +33,17 @@ public class Find extends WithQuery<List<JsonObject>> {
 
   @Override
   protected List<JsonObject> parseResponse(Object jsonValue) {
-    return ((JsonArray)jsonValue).stream()
-      .map(o -> (JsonObject)o)
+    return ((JsonArray) jsonValue).stream()
+      .map(o -> (JsonObject) o)
       .collect(Collectors.toList());
   }
 
   // fluent
+
+  @Override
+  public Find priority(int priority) {
+    return (Find) super.priority(priority);
+  }
 
   @Override
   public Find inCollection(String collection) {

--- a/src/main/java/com/noenv/wiremongo/mapping/FindBatch.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/FindBatch.java
@@ -10,6 +10,7 @@ public class FindBatch extends WithStreamQuery {
     public FindBatchCommand(String collection, JsonObject query) {
       this("findBatch", collection, query);
     }
+
     public FindBatchCommand(String method, String collection, JsonObject query) {
       super(method, collection, query);
     }
@@ -28,6 +29,11 @@ public class FindBatch extends WithStreamQuery {
   }
 
   // fluent
+
+  @Override
+  public FindBatch priority(int priority) {
+    return (FindBatch) super.priority(priority);
+  }
 
   @Override
   public FindBatch inCollection(String collection) {

--- a/src/main/java/com/noenv/wiremongo/mapping/FindBatchWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/FindBatchWithOptions.java
@@ -33,7 +33,7 @@ public class FindBatchWithOptions extends FindBatch {
 
   public FindBatchWithOptions(JsonObject json) {
     super(json);
-    options = Matcher.create(json.getJsonObject("options"), j -> new FindOptions((JsonObject)j), FindOptions::toJson);
+    options = Matcher.create(json.getJsonObject("options"), j -> new FindOptions((JsonObject) j), FindOptions::toJson);
   }
 
   @Override
@@ -58,6 +58,11 @@ public class FindBatchWithOptions extends FindBatch {
   }
 
   // fluent
+
+  @Override
+  public FindBatchWithOptions priority(int priority) {
+    return (FindBatchWithOptions) super.priority(priority);
+  }
 
   @Override
   public FindBatchWithOptions inCollection(String collection) {

--- a/src/main/java/com/noenv/wiremongo/mapping/FindOne.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/FindOne.java
@@ -62,6 +62,11 @@ public class FindOne extends WithQuery<JsonObject> {
   // fluent
 
   @Override
+  public FindOne priority(int priority) {
+    return (FindOne) super.priority(priority);
+  }
+
+  @Override
   public FindOne inCollection(String collection) {
     return (FindOne) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/FindOneAndDelete.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/FindOneAndDelete.java
@@ -37,6 +37,11 @@ public class FindOneAndDelete extends WithQuery<JsonObject> {
   // fluent
 
   @Override
+  public FindOneAndDelete priority(int priority) {
+    return (FindOneAndDelete) super.priority(priority);
+  }
+
+  @Override
   public FindOneAndDelete inCollection(String collection) {
     return (FindOneAndDelete) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/FindOneAndDeleteWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/FindOneAndDeleteWithOptions.java
@@ -36,7 +36,7 @@ public class FindOneAndDeleteWithOptions extends FindOneAndDelete {
 
   public FindOneAndDeleteWithOptions(JsonObject json) {
     super(json);
-    this.options = Matcher.create(json.getJsonObject("options"), j -> new FindOptions((JsonObject)j), FindOptions::toJson);
+    this.options = Matcher.create(json.getJsonObject("options"), j -> new FindOptions((JsonObject) j), FindOptions::toJson);
   }
 
   @Override
@@ -61,6 +61,11 @@ public class FindOneAndDeleteWithOptions extends FindOneAndDelete {
   }
 
   // fluent
+
+  @Override
+  public FindOneAndDeleteWithOptions priority(int priority) {
+    return (FindOneAndDeleteWithOptions) super.priority(priority);
+  }
 
   @Override
   public FindOneAndDeleteWithOptions inCollection(String collection) {

--- a/src/main/java/com/noenv/wiremongo/mapping/FindOneAndReplace.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/FindOneAndReplace.java
@@ -37,6 +37,11 @@ public class FindOneAndReplace extends WithReplace<JsonObject> {
   // fluent
 
   @Override
+  public FindOneAndReplace priority(int priority) {
+    return (FindOneAndReplace) super.priority(priority);
+  }
+
+  @Override
   public FindOneAndReplace inCollection(String collection) {
     return (FindOneAndReplace) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/FindOneAndReplaceWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/FindOneAndReplaceWithOptions.java
@@ -76,6 +76,11 @@ public class FindOneAndReplaceWithOptions extends FindOneAndReplace {
   // fluent
 
   @Override
+  public FindOneAndReplaceWithOptions priority(int priority) {
+    return (FindOneAndReplaceWithOptions) super.priority(priority);
+  }
+
+  @Override
   public FindOneAndReplaceWithOptions inCollection(String collection) {
     return (FindOneAndReplaceWithOptions) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/FindOneAndUpdate.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/FindOneAndUpdate.java
@@ -37,6 +37,11 @@ public class FindOneAndUpdate extends WithUpdate<JsonObject> {
   // fluent
 
   @Override
+  public FindOneAndUpdate priority(int priority) {
+    return (FindOneAndUpdate) super.priority(priority);
+  }
+
+  @Override
   public FindOneAndUpdate inCollection(String collection) {
     return (FindOneAndUpdate) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/FindOneAndUpdateWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/FindOneAndUpdateWithOptions.java
@@ -38,8 +38,8 @@ public class FindOneAndUpdateWithOptions extends FindOneAndUpdate {
 
   public FindOneAndUpdateWithOptions(JsonObject json) {
     super(json);
-    findOptions = Matcher.create(json.getJsonObject("findOptions"), j -> new FindOptions((JsonObject)j), FindOptions::toJson);
-    updateOptions = Matcher.create(json.getJsonObject("updateOptions"), j -> new UpdateOptions((JsonObject)j), UpdateOptions::toJson);
+    findOptions = Matcher.create(json.getJsonObject("findOptions"), j -> new FindOptions((JsonObject) j), FindOptions::toJson);
+    updateOptions = Matcher.create(json.getJsonObject("updateOptions"), j -> new UpdateOptions((JsonObject) j), UpdateOptions::toJson);
   }
 
   @Override
@@ -79,6 +79,11 @@ public class FindOneAndUpdateWithOptions extends FindOneAndUpdate {
   }
 
   // fluent
+
+  @Override
+  public FindOneAndUpdateWithOptions priority(int priority) {
+    return (FindOneAndUpdateWithOptions) super.priority(priority);
+  }
 
   @Override
   public FindOneAndUpdateWithOptions inCollection(String collection) {

--- a/src/main/java/com/noenv/wiremongo/mapping/FindWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/FindWithOptions.java
@@ -32,7 +32,7 @@ public class FindWithOptions extends Find {
 
   public FindWithOptions(JsonObject json) {
     super(json);
-    options = Matcher.create(json.getJsonObject("options"), j -> new FindOptions((JsonObject)j), FindOptions::toJson);
+    options = Matcher.create(json.getJsonObject("options"), j -> new FindOptions((JsonObject) j), FindOptions::toJson);
   }
 
   @Override
@@ -57,6 +57,11 @@ public class FindWithOptions extends Find {
   }
 
   // fluent
+
+  @Override
+  public FindWithOptions priority(int priority) {
+    return (FindWithOptions) super.priority(priority);
+  }
 
   @Override
   public FindWithOptions inCollection(Matcher<String> collection) {

--- a/src/main/java/com/noenv/wiremongo/mapping/Insert.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/Insert.java
@@ -30,6 +30,11 @@ public class Insert extends WithDocument {
   // fluent
 
   @Override
+  public Insert priority(int priority) {
+    return (Insert) super.priority(priority);
+  }
+
+  @Override
   public Insert inCollection(String collection) {
     return (Insert) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/InsertWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/InsertWithOptions.java
@@ -59,6 +59,11 @@ public class InsertWithOptions extends Insert {
   // fluent
 
   @Override
+  public InsertWithOptions priority(int priority) {
+    return (InsertWithOptions) super.priority(priority);
+  }
+
+  @Override
   public InsertWithOptions inCollection(String collection) {
     return (InsertWithOptions) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/ListIndexes.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/ListIndexes.java
@@ -28,6 +28,11 @@ public class ListIndexes extends WithCollection<JsonArray> {
   // fluent
 
   @Override
+  public ListIndexes priority(int priority) {
+    return (ListIndexes) super.priority(priority);
+  }
+
+  @Override
   public ListIndexes inCollection(String collection) {
     return (ListIndexes) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/Mapping.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/Mapping.java
@@ -11,6 +11,10 @@ public interface Mapping<T> extends Command {
 
   boolean matches(Command c);
 
+  int priority();
+
+  Mapping<T> priority(int priority);
+
   Stub<T> stub();
 
   Mapping<T> stub(Stub<T> stub);

--- a/src/main/java/com/noenv/wiremongo/mapping/MappingBase.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/MappingBase.java
@@ -10,6 +10,7 @@ public abstract class MappingBase<T> extends CommandBase implements Mapping<T> {
 
   private static final Stub DUMMY_STUB = () -> null;
   private LinkedList<Stub<T>> stubs = new LinkedList<>();
+  private int priority;
 
   public MappingBase(String method) {
     super(method);
@@ -18,7 +19,19 @@ public abstract class MappingBase<T> extends CommandBase implements Mapping<T> {
 
   public MappingBase(JsonObject json) {
     super(json.getString("method"));
+    priority = json.getInteger("priority", 0);
     parseStub(json);
+  }
+
+  @Override
+  public int priority() {
+    return priority;
+  }
+
+  @Override
+  public Mapping<T> priority(int priority) {
+    this.priority = priority;
+    return this;
   }
 
   @Override

--- a/src/main/java/com/noenv/wiremongo/mapping/RemoveDocument.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/RemoveDocument.java
@@ -36,6 +36,11 @@ public class RemoveDocument extends WithQuery<MongoClientDeleteResult> {
   // fluent
 
   @Override
+  public RemoveDocument priority(int priority) {
+    return (RemoveDocument) super.priority(priority);
+  }
+
+  @Override
   public RemoveDocument inCollection(String collection) {
     return (RemoveDocument) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/RemoveDocumentWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/RemoveDocumentWithOptions.java
@@ -59,6 +59,11 @@ public class RemoveDocumentWithOptions extends RemoveDocument {
   // fluent
 
   @Override
+  public RemoveDocumentWithOptions priority(int priority) {
+    return (RemoveDocumentWithOptions) super.priority(priority);
+  }
+
+  @Override
   public RemoveDocumentWithOptions inCollection(String collection) {
     return (RemoveDocumentWithOptions) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/RemoveDocuments.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/RemoveDocuments.java
@@ -36,6 +36,11 @@ public class RemoveDocuments extends WithQuery<MongoClientDeleteResult> {
   // fluent
 
   @Override
+  public RemoveDocuments priority(int priority) {
+    return (RemoveDocuments) super.priority(priority);
+  }
+
+  @Override
   public RemoveDocuments inCollection(String collection) {
     return (RemoveDocuments) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/RemoveDocumentsWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/RemoveDocumentsWithOptions.java
@@ -59,6 +59,11 @@ public class RemoveDocumentsWithOptions extends RemoveDocuments {
   // fluent
 
   @Override
+  public RemoveDocumentsWithOptions priority(int priority) {
+    return (RemoveDocumentsWithOptions) super.priority(priority);
+  }
+
+  @Override
   public RemoveDocumentsWithOptions inCollection(String collection) {
     return (RemoveDocumentsWithOptions) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/ReplaceDocuments.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/ReplaceDocuments.java
@@ -32,10 +32,15 @@ public class ReplaceDocuments extends WithReplace<MongoClientUpdateResult> {
 
   @Override
   protected MongoClientUpdateResult parseResponse(Object jsonValue) {
-    return new MongoClientUpdateResult((JsonObject)jsonValue);
+    return new MongoClientUpdateResult((JsonObject) jsonValue);
   }
 
   // fluent
+
+  @Override
+  public ReplaceDocuments priority(int priority) {
+    return (ReplaceDocuments) super.priority(priority);
+  }
 
   @Override
   public ReplaceDocuments inCollection(String collection) {

--- a/src/main/java/com/noenv/wiremongo/mapping/ReplaceDocumentsWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/ReplaceDocumentsWithOptions.java
@@ -32,7 +32,7 @@ public class ReplaceDocumentsWithOptions extends ReplaceDocuments {
 
   public ReplaceDocumentsWithOptions(JsonObject json) {
     super(json);
-    options = Matcher.create(json.getJsonObject("options"), j -> new UpdateOptions((JsonObject)j), UpdateOptions::toJson);
+    options = Matcher.create(json.getJsonObject("options"), j -> new UpdateOptions((JsonObject) j), UpdateOptions::toJson);
   }
 
   @Override
@@ -57,6 +57,11 @@ public class ReplaceDocumentsWithOptions extends ReplaceDocuments {
   }
 
   // fluent
+
+  @Override
+  public ReplaceDocumentsWithOptions priority(int priority) {
+    return (ReplaceDocumentsWithOptions) super.priority(priority);
+  }
 
   @Override
   public ReplaceDocumentsWithOptions inCollection(String collection) {

--- a/src/main/java/com/noenv/wiremongo/mapping/RunCommand.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/RunCommand.java
@@ -61,4 +61,11 @@ public class RunCommand extends MappingBase<JsonObject> {
     this.command = command;
     return this;
   }
+
+  // fluent
+
+  @Override
+  public RunCommand priority(int priority) {
+    return (RunCommand) super.priority(priority);
+  }
 }

--- a/src/main/java/com/noenv/wiremongo/mapping/Save.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/Save.java
@@ -27,6 +27,13 @@ public class Save extends WithDocument {
     super(json);
   }
 
+  // fluent
+
+  @Override
+  public Save priority(int priority) {
+    return (Save) super.priority(priority);
+  }
+
   @Override
   public Save inCollection(String collection) {
     return (Save) super.inCollection(collection);

--- a/src/main/java/com/noenv/wiremongo/mapping/SaveWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/SaveWithOptions.java
@@ -54,6 +54,11 @@ public class SaveWithOptions extends Save {
   // fluent
 
   @Override
+  public SaveWithOptions priority(int priority) {
+    return (SaveWithOptions) super.priority(priority);
+  }
+
+  @Override
   public SaveWithOptions inCollection(String collection) {
     return (SaveWithOptions) super.inCollection(collection);
   }

--- a/src/main/java/com/noenv/wiremongo/mapping/UpdateCollection.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/UpdateCollection.java
@@ -32,10 +32,15 @@ public class UpdateCollection extends WithUpdate<MongoClientUpdateResult> {
 
   @Override
   protected MongoClientUpdateResult parseResponse(Object jsonValue) {
-    return new MongoClientUpdateResult((JsonObject)jsonValue);
+    return new MongoClientUpdateResult((JsonObject) jsonValue);
   }
 
   // fluent
+
+  @Override
+  public UpdateCollection priority(int priority) {
+    return (UpdateCollection) super.priority(priority);
+  }
 
   @Override
   public UpdateCollection inCollection(String collection) {

--- a/src/main/java/com/noenv/wiremongo/mapping/UpdateCollectionWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/UpdateCollectionWithOptions.java
@@ -33,7 +33,7 @@ public class UpdateCollectionWithOptions extends UpdateCollection {
 
   public UpdateCollectionWithOptions(JsonObject json) {
     super(json);
-    options = Matcher.create(json.getJsonObject("options"), j -> new UpdateOptions((JsonObject)j), UpdateOptions::toJson);
+    options = Matcher.create(json.getJsonObject("options"), j -> new UpdateOptions((JsonObject) j), UpdateOptions::toJson);
   }
 
   @Override
@@ -63,6 +63,11 @@ public class UpdateCollectionWithOptions extends UpdateCollection {
   }
 
   // fluent
+
+  @Override
+  public UpdateCollectionWithOptions priority(int priority) {
+    return (UpdateCollectionWithOptions) super.priority(priority);
+  }
 
   @Override
   public UpdateCollectionWithOptions inCollection(String collection) {

--- a/src/test/java/com/noenv/wiremongo/PriorityTest.java
+++ b/src/test/java/com/noenv/wiremongo/PriorityTest.java
@@ -1,0 +1,53 @@
+package com.noenv.wiremongo;
+
+import com.noenv.wiremongo.mapping.Mapping;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class PriorityTest {
+
+  private WireMongo wiremongo;
+
+  @Before
+  public void setUp() {
+    wiremongo = new WireMongo();
+  }
+
+  @Test
+  public void testDefaultPriority(TestContext ctx) {
+    Mapping<?> a = wiremongo.count().returns(42L);
+    Mapping<?> b = wiremongo.count().returns(21L);
+
+    ctx.assertTrue(b.priority() > a.priority()); // more recently added should have higher priority
+
+    wiremongo.getClient().count("foo", new JsonObject(),
+      ctx.asyncAssertSuccess(r -> ctx.assertEquals(21L, r)));
+  }
+
+  @Test
+  public void testPriority(TestContext ctx) {
+    wiremongo.count().priority(20).returns(42L);
+    wiremongo.count().priority(10).returns(21L);
+    wiremongo.getClient().count("foo", new JsonObject(),
+      ctx.asyncAssertSuccess(r -> ctx.assertEquals(42L, r)));
+  }
+
+  @Test
+  public void testPriorityFiles(TestContext ctx) {
+    wiremongo = new WireMongo(Vertx.vertx());
+    wiremongo.readFileMappings("wiremongo-mocks")
+      .flatMap(x -> {
+        Promise<Long> p = Promise.promise();
+        wiremongo.getClient().count("priority", new JsonObject().put("test", "testPriorityFile"), p);
+        return p.future();
+      })
+      .onComplete(ctx.asyncAssertSuccess(r -> ctx.assertEquals(333L, r)));
+  }
+}

--- a/src/test/java/com/noenv/wiremongo/mapping/save/SaveTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/save/SaveTest.java
@@ -19,58 +19,39 @@ public class SaveTest extends TestBase {
   public void testSave(TestContext ctx) {
     Async async = ctx.async();
 
-    mock
-      .save()
+    mock.save()
       .inCollection("save")
       .withDocument(equalToJson(new JsonObject().put("test", "testInsert"), true))
       .returns("5c45f450c29de454289c5705");
 
-    db
-      .rxSave(
-        "save",
-        new JsonObject()
-          .put("test", "testInsert")
-          .put("createdAt", Instant.now())
-      )
-      .subscribe(
-        r -> {
-          ctx.assertEquals("5c45f450c29de454289c5705", r);
-          async.complete();
-        },
-        ctx::fail
-      );
+    db.rxSave("save", new JsonObject()
+      .put("test", "testInsert")
+      .put("createdAt", Instant.now()))
+      .subscribe(r -> {
+        ctx.assertEquals("5c45f450c29de454289c5705", r);
+        async.complete();
+      }, ctx::fail);
   }
 
   @Test
   public void testSaveWithId(TestContext ctx) {
     Async async = ctx.async();
 
-    mock
-      .save()
+    mock.save()
       .inCollection("save")
-      .withDocument(equalToJson(
-        new JsonObject()
-          .put("_id", "testId")
-          .put("test", "testInsert"),
-        true
-      ))
-      .returns("");
+      .withDocument(equalToJson(new JsonObject()
+        .put("_id", "testId")
+        .put("test", "testInsert"), true))
+      .returns("5c45f450c29de454289c5721");
 
-    db
-      .rxSave(
-        "save",
-        new JsonObject()
-          .put("_id", "testId")
-          .put("test", "testInsert")
-          .put("createdAt", Instant.now())
-      )
-      .subscribe(
-        r -> {
-          ctx.assertEquals("5c45f450c29de454289c5705", r);
-          async.complete();
-        },
-        ctx::fail
-      );
+    db.rxSave("save", new JsonObject()
+      .put("_id", "testId")
+      .put("test", "testInsert")
+      .put("createdAt", Instant.now()))
+      .subscribe(r -> {
+        ctx.assertEquals("5c45f450c29de454289c5721", r);
+        async.complete();
+      }, ctx::fail);
   }
 
   @Test

--- a/src/test/resources/wiremongo-mocks/priority/01_count.json
+++ b/src/test/resources/wiremongo-mocks/priority/01_count.json
@@ -1,0 +1,12 @@
+{
+  "method": "count",
+  "collection": {
+    "equalTo": "priority"
+  },
+  "query": {
+    "equalTo": {
+      "test": "testPriorityFile"
+    }
+  },
+  "response": 111
+}

--- a/src/test/resources/wiremongo-mocks/priority/02_count.json
+++ b/src/test/resources/wiremongo-mocks/priority/02_count.json
@@ -1,0 +1,13 @@
+{
+  "method": "count",
+  "collection": {
+    "equalTo": "priority"
+  },
+  "query": {
+    "equalTo": {
+      "test": "testPriorityFile"
+    }
+  },
+  "response": 333,
+  "priority": 999
+}

--- a/src/test/resources/wiremongo-mocks/priority/03_count.json
+++ b/src/test/resources/wiremongo-mocks/priority/03_count.json
@@ -1,0 +1,13 @@
+{
+  "method": "count",
+  "collection": {
+    "equalTo": "priority"
+  },
+  "query": {
+    "equalTo": {
+      "test": "testPriorityFile"
+    }
+  },
+  "response": 222,
+  "priority": 1
+}


### PR DESCRIPTION
This adds a priority feature that allows setting a priority number for a mapping that can be used by WireMongo to choose mappings when more than one match. Fixes issue #1