### PR TITLE
add match-all feature

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -218,6 +218,22 @@ wiremongo.insert()
 
 The above code will return ids for the first two and a duplicate key error for every subsequent insert command.
 
+== Match All
+
+If you want to add a mapping that matches *all* mongo commands, you can use `matchAll`:
+
+[source,java]
+----
+wiremongo.matchAll()
+  .stub(c -> {
+    ctx.assertTrue(c.method().equals("replaceDocuments") || c.method().equals("insert"));
+    log("mongo received command: " + c);
+    return 42;
+  });
+----
+
+Match All is not supported for file mappings however.
+
 == Files
 
 Mocks can also be defined in json files. You can ask wiremongo to read files from a directory like this:

--- a/src/main/java/com/noenv/wiremongo/WireMongoClient.java
+++ b/src/main/java/com/noenv/wiremongo/WireMongoClient.java
@@ -1,6 +1,7 @@
 package com.noenv.wiremongo;
 
 import com.noenv.wiremongo.command.Command;
+import com.noenv.wiremongo.command.CountCommand;
 import com.noenv.wiremongo.command.RunCommandCommand;
 import com.noenv.wiremongo.command.aggregate.AggregateBaseCommand;
 import com.noenv.wiremongo.command.aggregate.AggregateWithOptionsCommand;
@@ -9,7 +10,6 @@ import com.noenv.wiremongo.command.bulkwrite.BulkWriteWithOptionsCommand;
 import com.noenv.wiremongo.command.collection.CreateCollectionCommand;
 import com.noenv.wiremongo.command.collection.DropCollectionCommand;
 import com.noenv.wiremongo.command.collection.GetCollectionsCommand;
-import com.noenv.wiremongo.command.CountCommand;
 import com.noenv.wiremongo.command.distinct.DistinctBatchBaseCommand;
 import com.noenv.wiremongo.command.distinct.DistinctBatchWithQueryCommand;
 import com.noenv.wiremongo.command.distinct.DistinctCommand;

--- a/src/main/java/com/noenv/wiremongo/WireMongoCommands.java
+++ b/src/main/java/com/noenv/wiremongo/WireMongoCommands.java
@@ -1,21 +1,23 @@
 package com.noenv.wiremongo;
 
-import com.noenv.wiremongo.mapping.*;
+import com.noenv.wiremongo.mapping.Count;
+import com.noenv.wiremongo.mapping.Mapping;
+import com.noenv.wiremongo.mapping.MatchAll;
+import com.noenv.wiremongo.mapping.RunCommand;
 import com.noenv.wiremongo.mapping.aggregate.Aggregate;
 import com.noenv.wiremongo.mapping.aggregate.AggregateWithOptions;
 import com.noenv.wiremongo.mapping.bulkwrite.BulkWrite;
 import com.noenv.wiremongo.mapping.bulkwrite.BulkWriteWithOptions;
+import com.noenv.wiremongo.mapping.collection.CreateCollection;
 import com.noenv.wiremongo.mapping.collection.DropCollection;
 import com.noenv.wiremongo.mapping.collection.GetCollections;
-import com.noenv.wiremongo.mapping.Count;
-import com.noenv.wiremongo.mapping.collection.CreateCollection;
-import com.noenv.wiremongo.mapping.index.CreateIndex;
-import com.noenv.wiremongo.mapping.index.CreateIndexWithOptions;
 import com.noenv.wiremongo.mapping.distinct.Distinct;
 import com.noenv.wiremongo.mapping.distinct.DistinctBatch;
 import com.noenv.wiremongo.mapping.distinct.DistinctBatchWithQuery;
 import com.noenv.wiremongo.mapping.distinct.DistinctWithQuery;
 import com.noenv.wiremongo.mapping.find.*;
+import com.noenv.wiremongo.mapping.index.CreateIndex;
+import com.noenv.wiremongo.mapping.index.CreateIndexWithOptions;
 import com.noenv.wiremongo.mapping.index.DropIndex;
 import com.noenv.wiremongo.mapping.index.ListIndexes;
 import com.noenv.wiremongo.mapping.insert.Insert;
@@ -32,6 +34,10 @@ import com.noenv.wiremongo.mapping.update.UpdateCollection;
 import com.noenv.wiremongo.mapping.update.UpdateCollectionWithOptions;
 
 public interface WireMongoCommands {
+
+  default MatchAll matchAll() {
+    return addMapping(new MatchAll());
+  }
 
   default Insert insert() {
     return addMapping(new Insert());

--- a/src/main/java/com/noenv/wiremongo/mapping/MatchAll.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/MatchAll.java
@@ -1,0 +1,20 @@
+package com.noenv.wiremongo.mapping;
+
+import com.noenv.wiremongo.command.Command;
+
+public class MatchAll extends MappingBase<Object, Command, MatchAll> {
+
+  public MatchAll() {
+    super("matchAll");
+  }
+
+  @Override
+  protected Object parseResponse(Object jsonValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean matches(Command c) {
+    return true;
+  }
+}

--- a/src/test/java/com/noenv/wiremongo/mapping/MatchAllTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/MatchAllTest.java
@@ -1,0 +1,30 @@
+package com.noenv.wiremongo.mapping;
+
+import com.noenv.wiremongo.TestBase;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class MatchAllTest extends TestBase {
+
+  @Test
+  public void testMatchAll(TestContext ctx) {
+    Async async = ctx.async();
+    Mapping m = mock.matchAll()
+      .stub(c -> {
+        ctx.assertEquals("count", c.method());
+        return 41L;
+      });
+
+    db.rxCount("count", new JsonObject().put("test", "testCount"))
+      .subscribe(s -> {
+        ctx.assertEquals(41L, s);
+        mock.removeMapping(m);
+        async.complete();
+      }, ctx::fail);
+  }
+}


### PR DESCRIPTION
Sometimes it may be useful to create a mapping that matches all mongo commands. This PR implements such a feature.