### PR TITLE
Fixes #25

### DIFF
--- a/src/main/java/com/noenv/wiremongo/WireMongoClient.java
+++ b/src/main/java/com/noenv/wiremongo/WireMongoClient.java
@@ -13,7 +13,10 @@ import com.noenv.wiremongo.command.collection.CreateCollectionCommand;
 import com.noenv.wiremongo.command.collection.CreateCollectionWithOptionsCommand;
 import com.noenv.wiremongo.command.collection.DropCollectionCommand;
 import com.noenv.wiremongo.command.collection.GetCollectionsCommand;
-import com.noenv.wiremongo.command.distinct.*;
+import com.noenv.wiremongo.command.distinct.DistinctBatchBaseCommand;
+import com.noenv.wiremongo.command.distinct.DistinctBatchWithQueryCommand;
+import com.noenv.wiremongo.command.distinct.DistinctCommand;
+import com.noenv.wiremongo.command.distinct.DistinctWithQueryCommand;
 import com.noenv.wiremongo.command.find.*;
 import com.noenv.wiremongo.command.index.*;
 import com.noenv.wiremongo.command.insert.InsertBaseCommand;
@@ -128,7 +131,7 @@ public class WireMongoClient implements MongoClient {
 
   @Override
   public Future<MongoClientUpdateResult> updateCollection(String collection, JsonObject query, JsonArray update) {
-    return call(new UpdateCollectionBaseCommand<>(collection, query, update));
+    return call(new UpdateCollectionBaseCommand<>("updateCollectionAggregationPipeline", collection, query, update));
   }
 
   @Override
@@ -143,14 +146,14 @@ public class WireMongoClient implements MongoClient {
   }
 
   @Override
-  public MongoClient updateCollectionWithOptions(String collection, JsonObject query, JsonArray update, UpdateOptions updateOptions, Handler<AsyncResult<MongoClientUpdateResult>> handler) {
-    updateCollectionWithOptions(collection, query, update, updateOptions).onComplete(handler);
+  public MongoClient updateCollectionWithOptions(String collection, JsonObject query, JsonArray update, UpdateOptions options, Handler<AsyncResult<MongoClientUpdateResult>> handler) {
+    updateCollectionWithOptions(collection, query, update, options).onComplete(handler);
     return this;
   }
 
   @Override
-  public Future<MongoClientUpdateResult> updateCollectionWithOptions(String collection, JsonObject query, JsonArray update, UpdateOptions updateOptions) {
-    return call(new UpdateCollectionWithOptionsCommand<>(collection, query, update, updateOptions));
+  public Future<MongoClientUpdateResult> updateCollectionWithOptions(String collection, JsonObject query, JsonArray update, UpdateOptions options) {
+    return call(new UpdateCollectionWithOptionsCommand<>("updateCollectionWithOptionsAggregationPipeline", collection, query, update, options));
   }
 
   @Override

--- a/src/main/java/com/noenv/wiremongo/WireMongoCommands.java
+++ b/src/main/java/com/noenv/wiremongo/WireMongoCommands.java
@@ -57,7 +57,7 @@ public interface WireMongoCommands {
   }
 
   default UpdateCollection<JsonArray> updateCollectionAggregationPipeline() {
-    return addMapping(new UpdateCollection<>());
+    return addMapping(new UpdateCollection<>("updateCollectionAggregationPipeline"));
   }
 
   default UpdateCollectionWithOptions<JsonObject> updateCollectionWithOptions() {
@@ -65,7 +65,7 @@ public interface WireMongoCommands {
   }
 
   default UpdateCollectionWithOptions<JsonArray> updateCollectionWithOptionsAggregationPipeline() {
-    return addMapping(new UpdateCollectionWithOptions<>());
+    return addMapping(new UpdateCollectionWithOptions<>("updateCollectionWithOptionsAggregationPipeline"));
   }
 
   default Find find() {

--- a/src/main/java/com/noenv/wiremongo/command/update/UpdateCollectionWithOptionsCommand.java
+++ b/src/main/java/com/noenv/wiremongo/command/update/UpdateCollectionWithOptionsCommand.java
@@ -9,7 +9,11 @@ public class UpdateCollectionWithOptionsCommand<T> extends UpdateCollectionBaseC
   private final UpdateOptions options;
 
   public UpdateCollectionWithOptionsCommand(String collection, JsonObject query, T update, UpdateOptions options) {
-    super("updateCollectionWithOptions", collection, query, update);
+    this("updateCollectionWithOptions", collection, query, update, options);
+  }
+
+  public UpdateCollectionWithOptionsCommand(String method, String collection, JsonObject query, T update, UpdateOptions options) {
+    super(method, collection, query, update);
     this.options = options;
   }
 

--- a/src/main/java/com/noenv/wiremongo/mapping/Mapping.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/Mapping.java
@@ -106,9 +106,11 @@ public interface Mapping<T, U extends Command, C extends Mapping<T, U, C>> {
         case "saveWithOptions":
           return new SaveWithOptions(json);
         case "updateCollection":
-          return new UpdateCollection(json);
+        case "updateCollectionAggregationPipeline":
+          return new UpdateCollection<>(json);
         case "updateCollectionWithOptions":
-          return new UpdateCollectionWithOptions(json);
+        case "updateCollectionWithOptionsAggregationPipeline":
+          return new UpdateCollectionWithOptions<>(json);
         case "find":
           return new Find(json);
         case "findWithOptions":

--- a/src/main/java/com/noenv/wiremongo/mapping/update/UpdateCollectionWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/update/UpdateCollectionWithOptions.java
@@ -8,8 +8,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.MongoClientUpdateResult;
 import io.vertx.ext.mongo.UpdateOptions;
 
-import static com.noenv.wiremongo.matching.EqualsMatcher.equalTo;
-
 @SuppressWarnings("squid:MaximumInheritanceDepth")
 public class UpdateCollectionWithOptions<T> extends UpdateCollectionBase<T, UpdateCollectionWithOptionsCommand<T>, UpdateCollectionWithOptions<T>> {
 
@@ -17,6 +15,10 @@ public class UpdateCollectionWithOptions<T> extends UpdateCollectionBase<T, Upda
 
   public UpdateCollectionWithOptions() {
     super("updateCollectionWithOptions");
+  }
+
+  public UpdateCollectionWithOptions(String method) {
+    super(method);
   }
 
   public UpdateCollectionWithOptions(JsonObject json) {

--- a/src/test/resources/wiremongo-mocks/update/updateCollectionAggregationPipeline.json
+++ b/src/test/resources/wiremongo-mocks/update/updateCollectionAggregationPipeline.json
@@ -1,5 +1,5 @@
 {
-  "method": "updateCollection",
+  "method": "updateCollectionAggregationPipeline",
   "collection": {
     "equalTo": "updatecollection"
   },

--- a/src/test/resources/wiremongo-mocks/update/updateCollectionWithOptionsAggregationPipeline.json
+++ b/src/test/resources/wiremongo-mocks/update/updateCollectionWithOptionsAggregationPipeline.json
@@ -1,5 +1,5 @@
 {
-  "method": "updateCollectionWithOptions",
+  "method": "updateCollectionWithOptionsAggregationPipeline",
   "collection": {
     "equalTo": "updatecollectionwithoptions"
   },


### PR DESCRIPTION
Extend WithUpdate command by method ctor, which allows us to specify a different method-string for invocations of updateCollection calls. Thus we do not even care for updates with a pipeline (JsonArray) in updateCollection(WithOptions), as the mapping already fails on method level.

Signed-off-by: Christoph Spörk <christoph.spoerk@gmail.com>