### PR TITLE
chore(options): Add/review tests for various WithOptions tests

### DIFF
--- a/src/main/java/com/noenv/wiremongo/WireMongo.java
+++ b/src/main/java/com/noenv/wiremongo/WireMongo.java
@@ -6,9 +6,9 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.streams.ReadStream;
 
 import java.util.*;

--- a/src/main/java/com/noenv/wiremongo/WireMongoClient.java
+++ b/src/main/java/com/noenv/wiremongo/WireMongoClient.java
@@ -45,6 +45,7 @@ import java.util.List;
 
 public class WireMongoClient implements MongoClient {
 
+  public static final String NOT_IMPLEMENTED = "not implemented";
   private static WireMongoClient instance;
   private WireMongo wireMongo;
 
@@ -492,7 +493,7 @@ public class WireMongoClient implements MongoClient {
   }
 
   @Override
-  public MongoClient distinct(String collection, String fieldName, String resultClassname, Handler<AsyncResult<JsonArray>> handler, DistinctOptions distinctOptions) {
+  public MongoClient distinct(String collection, String fieldName, String resultClassname, DistinctOptions distinctOptions, Handler<AsyncResult<JsonArray>> handler) {
     distinct(collection, fieldName, resultClassname, distinctOptions).onComplete(handler);
     return this;
   }
@@ -514,7 +515,7 @@ public class WireMongoClient implements MongoClient {
   }
 
   @Override
-  public MongoClient distinctWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, Handler<AsyncResult<JsonArray>> handler, DistinctOptions distinctOptions) {
+  public MongoClient distinctWithQuery(String collection, String fieldName, String resultClassname, JsonObject query, DistinctOptions distinctOptions, Handler<AsyncResult<JsonArray>> handler) {
     distinctWithQuery(collection, fieldName, resultClassname, query, distinctOptions).onComplete(handler);
     return this;
   }
@@ -577,7 +578,7 @@ public class WireMongoClient implements MongoClient {
 
   @Override
   public Future<MongoGridFsClient> createDefaultGridFsBucketService() {
-    throw new UnsupportedOperationException("not implemented");
+    throw new UnsupportedOperationException(NOT_IMPLEMENTED);
   }
 
   @Override
@@ -588,12 +589,12 @@ public class WireMongoClient implements MongoClient {
 
   @Override
   public Future<MongoGridFsClient> createGridFsBucketService(String s) {
-    throw new UnsupportedOperationException("not implemented");
+    throw new UnsupportedOperationException(NOT_IMPLEMENTED);
   }
 
   @Override
   public ReadStream<ChangeStreamDocument<JsonObject>> watch(String s, JsonArray jsonArray, boolean b, int i) {
-    throw new UnsupportedOperationException("not implemented");
+    throw new UnsupportedOperationException(NOT_IMPLEMENTED);
   }
 
   @Override

--- a/src/main/java/com/noenv/wiremongo/mapping/CountWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/CountWithOptions.java
@@ -6,9 +6,6 @@ import com.noenv.wiremongo.matching.JsonMatcher;
 import com.noenv.wiremongo.matching.Matcher;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.CountOptions;
-import io.vertx.ext.mongo.CreateCollectionOptions;
-
-import static com.noenv.wiremongo.matching.EqualsMatcher.equalTo;
 
 public class CountWithOptions extends WithQuery<Long, CountWithOptionsCommand, CountWithOptions> {
 

--- a/src/main/java/com/noenv/wiremongo/mapping/aggregate/AggregateWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/aggregate/AggregateWithOptions.java
@@ -6,9 +6,6 @@ import com.noenv.wiremongo.matching.JsonMatcher;
 import com.noenv.wiremongo.matching.Matcher;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.AggregateOptions;
-import io.vertx.ext.mongo.CreateCollectionOptions;
-
-import static com.noenv.wiremongo.matching.EqualsMatcher.equalTo;
 
 @SuppressWarnings("squid:MaximumInheritanceDepth")
 public class AggregateWithOptions extends AggregateBase<AggregateWithOptionsCommand, AggregateWithOptions> {

--- a/src/main/java/com/noenv/wiremongo/mapping/bulkwrite/BulkWriteWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/bulkwrite/BulkWriteWithOptions.java
@@ -6,9 +6,6 @@ import com.noenv.wiremongo.matching.JsonMatcher;
 import com.noenv.wiremongo.matching.Matcher;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.BulkWriteOptions;
-import io.vertx.ext.mongo.CreateCollectionOptions;
-
-import static com.noenv.wiremongo.matching.EqualsMatcher.equalTo;
 
 public class BulkWriteWithOptions extends BulkWriteBase<BulkWriteWithOptionsCommand, BulkWriteWithOptions> {
 

--- a/src/main/java/com/noenv/wiremongo/mapping/collection/CreateCollectionWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/collection/CreateCollectionWithOptions.java
@@ -6,9 +6,6 @@ import com.noenv.wiremongo.matching.JsonMatcher;
 import com.noenv.wiremongo.matching.Matcher;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.CreateCollectionOptions;
-import io.vertx.ext.mongo.DistinctOptions;
-
-import static com.noenv.wiremongo.matching.EqualsMatcher.equalTo;
 
 public class CreateCollectionWithOptions extends WithCollection<Void, CreateCollectionWithOptionsCommand, CreateCollectionWithOptions> {
 

--- a/src/main/java/com/noenv/wiremongo/mapping/distinct/DistinctBatchWithQuery.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/distinct/DistinctBatchWithQuery.java
@@ -48,4 +48,13 @@ public class DistinctBatchWithQuery extends DistinctBatchBase<DistinctBatchWithQ
     this.query = query;
     return self();
   }
+
+  public DistinctBatchWithQuery withBatchSize(Integer batchSize) {
+    return withBatchSize(equalTo(batchSize));
+  }
+
+  public DistinctBatchWithQuery withBatchSize(Matcher<Integer> batchSize) {
+    this.batchSize = batchSize;
+    return self();
+  }
 }

--- a/src/main/java/com/noenv/wiremongo/mapping/distinct/DistinctWithQuery.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/distinct/DistinctWithQuery.java
@@ -71,7 +71,7 @@ public class DistinctWithQuery extends WithQuery<JsonArray, DistinctWithQueryCom
   }
 
   public DistinctWithQuery withOptions(DistinctOptions options) {
-    return withOptions(JsonMatcher.equalToJson(options.toJson(),DistinctOptions::toJson));
+    return withOptions(JsonMatcher.equalToJson(options.toJson(), DistinctOptions::toJson));
   }
 
   public DistinctWithQuery withOptions(Matcher<DistinctOptions> options) {

--- a/src/main/java/com/noenv/wiremongo/mapping/find/FindBase.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/find/FindBase.java
@@ -10,15 +10,15 @@ import java.util.stream.Collectors;
 
 public abstract class FindBase<U extends FindBaseCommand, C extends FindBase<U, C>> extends WithQuery<List<JsonObject>, U, C> {
 
-  public FindBase() {
+  protected FindBase() {
     this("find");
   }
 
-  public FindBase(String method) {
+  protected FindBase(String method) {
     super(method);
   }
 
-  public FindBase(JsonObject json) {
+  protected FindBase(JsonObject json) {
     super(json);
   }
 
@@ -30,7 +30,7 @@ public abstract class FindBase<U extends FindBaseCommand, C extends FindBase<U, 
   @Override
   protected List<JsonObject> parseResponse(Object jsonValue) {
     return ((JsonArray) jsonValue).stream()
-      .map(o -> (JsonObject) o)
+      .map(JsonObject.class::cast)
       .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/noenv/wiremongo/mapping/find/FindBatchWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/find/FindBatchWithOptions.java
@@ -6,10 +6,7 @@ import com.noenv.wiremongo.command.find.FindBatchWithOptionsCommand;
 import com.noenv.wiremongo.matching.JsonMatcher;
 import com.noenv.wiremongo.matching.Matcher;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.mongo.CreateCollectionOptions;
 import io.vertx.ext.mongo.FindOptions;
-
-import static com.noenv.wiremongo.matching.EqualsMatcher.equalTo;
 
 
 @SuppressWarnings("squid:MaximumInheritanceDepth")

--- a/src/main/java/com/noenv/wiremongo/mapping/find/FindOneAndDeleteWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/find/FindOneAndDeleteWithOptions.java
@@ -5,10 +5,7 @@ import com.noenv.wiremongo.command.find.FindOneAndDeleteWithOptionsCommand;
 import com.noenv.wiremongo.matching.JsonMatcher;
 import com.noenv.wiremongo.matching.Matcher;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.mongo.CreateCollectionOptions;
 import io.vertx.ext.mongo.FindOptions;
-
-import static com.noenv.wiremongo.matching.EqualsMatcher.equalTo;
 
 @SuppressWarnings("squid:MaximumInheritanceDepth")
 public class FindOneAndDeleteWithOptions extends FindOneAndDeleteBase<FindOneAndDeleteWithOptionsCommand, FindOneAndDeleteWithOptions> {

--- a/src/main/java/com/noenv/wiremongo/mapping/find/FindOneAndReplaceWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/find/FindOneAndReplaceWithOptions.java
@@ -5,11 +5,8 @@ import com.noenv.wiremongo.command.find.FindOneAndReplaceWithOptionsCommand;
 import com.noenv.wiremongo.matching.JsonMatcher;
 import com.noenv.wiremongo.matching.Matcher;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.mongo.CreateCollectionOptions;
 import io.vertx.ext.mongo.FindOptions;
 import io.vertx.ext.mongo.UpdateOptions;
-
-import static com.noenv.wiremongo.matching.EqualsMatcher.equalTo;
 
 @SuppressWarnings("squid:MaximumInheritanceDepth")
 public class FindOneAndReplaceWithOptions extends FindOneAndReplaceBase<FindOneAndReplaceWithOptionsCommand, FindOneAndReplaceWithOptions> {

--- a/src/main/java/com/noenv/wiremongo/mapping/find/FindOneAndUpdateWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/find/FindOneAndUpdateWithOptions.java
@@ -5,11 +5,8 @@ import com.noenv.wiremongo.command.find.FindOneAndUpdateWithOptionsCommand;
 import com.noenv.wiremongo.matching.JsonMatcher;
 import com.noenv.wiremongo.matching.Matcher;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.mongo.CreateCollectionOptions;
 import io.vertx.ext.mongo.FindOptions;
 import io.vertx.ext.mongo.UpdateOptions;
-
-import static com.noenv.wiremongo.matching.EqualsMatcher.equalTo;
 
 @SuppressWarnings("squid:MaximumInheritanceDepth")
 public class FindOneAndUpdateWithOptions extends FindOneAndUpdateBase<FindOneAndUpdateWithOptionsCommand, FindOneAndUpdateWithOptions> {

--- a/src/main/java/com/noenv/wiremongo/mapping/find/FindWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/find/FindWithOptions.java
@@ -5,10 +5,7 @@ import com.noenv.wiremongo.command.find.FindWithOptionsCommand;
 import com.noenv.wiremongo.matching.JsonMatcher;
 import com.noenv.wiremongo.matching.Matcher;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.mongo.CreateCollectionOptions;
 import io.vertx.ext.mongo.FindOptions;
-
-import static com.noenv.wiremongo.matching.EqualsMatcher.equalTo;
 
 @SuppressWarnings("squid:MaximumInheritanceDepth")
 public class FindWithOptions extends FindBase<FindWithOptionsCommand, FindWithOptions> {

--- a/src/main/java/com/noenv/wiremongo/mapping/index/CreateIndexWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/index/CreateIndexWithOptions.java
@@ -5,10 +5,7 @@ import com.noenv.wiremongo.command.index.CreateIndexWithOptionsCommand;
 import com.noenv.wiremongo.matching.JsonMatcher;
 import com.noenv.wiremongo.matching.Matcher;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.mongo.CreateCollectionOptions;
 import io.vertx.ext.mongo.IndexOptions;
-
-import static com.noenv.wiremongo.matching.EqualsMatcher.equalTo;
 
 public class CreateIndexWithOptions extends CreateIndexBase<CreateIndexWithOptionsCommand, CreateIndexWithOptions> {
 

--- a/src/main/java/com/noenv/wiremongo/mapping/index/CreateIndexes.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/index/CreateIndexes.java
@@ -12,8 +12,6 @@ import io.vertx.ext.mongo.IndexModel;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.noenv.wiremongo.matching.EqualsMatcher.equalTo;
-
 public class CreateIndexes extends WithCollection<Void, CreateIndexesCommand, CreateIndexes> {
 
   private Matcher<List<IndexModel>> indexModels;

--- a/src/main/java/com/noenv/wiremongo/mapping/replace/ReplaceDocumentsWithOptions.java
+++ b/src/main/java/com/noenv/wiremongo/mapping/replace/ReplaceDocumentsWithOptions.java
@@ -7,8 +7,6 @@ import com.noenv.wiremongo.matching.Matcher;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.UpdateOptions;
 
-import static com.noenv.wiremongo.matching.EqualsMatcher.equalTo;
-
 @SuppressWarnings("squid:MaximumInheritanceDepth")
 public class ReplaceDocumentsWithOptions extends ReplaceDocumentsBase<ReplaceDocumentsWithOptionsCommand, ReplaceDocumentsWithOptions> {
 

--- a/src/test/java/com/noenv/wiremongo/TestBase.java
+++ b/src/test/java/com/noenv/wiremongo/TestBase.java
@@ -1,8 +1,13 @@
 package com.noenv.wiremongo;
 
+import com.mongodb.MongoException;
+import io.reactivex.rxjava3.functions.Consumer;
+import io.vertx.core.Handler;
+import io.vertx.core.impl.NoStackTraceThrowable;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.rxjava3.CompletableHelper;
 import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.ext.mongo.MongoClient;
 import org.junit.Before;
@@ -17,16 +22,69 @@ public abstract class TestBase {
 
   @BeforeClass
   public static void setUp(TestContext ctx) {
-    Async async = ctx.async();
     mock = new com.noenv.rxjava3.wiremongo.WireMongo(Vertx.vertx());
     mock.readFileMappings("wiremongo-mocks")
-      .subscribe(async::complete, ctx::fail);
+      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertSuccess()));
 
+  }
+
+  public static Consumer<? super Throwable> assertNoMappingFoundError(TestContext ctx) {
+    return assertNoMappingFoundError(ctx, null);
+  }
+
+  public static Consumer<? super Throwable> assertNoMappingFoundError(TestContext ctx, Async latch) {
+    return throwable -> {
+      ctx.assertTrue(throwable instanceof RuntimeException || throwable instanceof NoStackTraceThrowable, "throwable should be instance of RuntimeException or NoStackTraceThrowable");
+      ctx.assertTrue(throwable.getMessage() != null && throwable.getMessage().startsWith("no mapping found: "), "throwable message should start with `no mapping found: `");
+      System.err.println("Above `no mapping found` error is intentional");
+      if (latch != null) {
+        latch.countDown();
+      }
+    };
+  }
+
+  public static <T extends MongoException> Consumer<? super Throwable> assertMongoException(TestContext ctx, Class<T> mongoExceptionClass, Consumer<T> throwableConsumer) {
+    return throwable -> {
+      ctx.assertTrue(mongoExceptionClass.isInstance(throwable), String.format("throwable should be instance of %s", mongoExceptionClass.getName()));
+      if (throwableConsumer != null) {
+        throwableConsumer.accept(mongoExceptionClass.cast(throwable));
+      }
+    };
+  }
+
+  public static Consumer<? super Throwable> assertMongoException(TestContext ctx, Class<? extends MongoException> mongoExceptionClass) {
+    return assertMongoException(ctx, mongoExceptionClass, throwable -> {
+    });
+  }
+
+  public static Handler<Throwable> handleNoMappingFoundError(TestContext ctx) {
+    return throwable -> {
+      try {
+        assertNoMappingFoundError(ctx).accept(throwable);
+      } catch (Throwable e) {
+        ctx.fail(e);
+      }
+    };
+  }
+
+  public static Consumer<Throwable> assertIntentionalError(TestContext ctx, String errMessage) {
+    return throwable -> ctx.assertEquals(errMessage, throwable.getMessage());
+  }
+
+  public static Handler<Throwable> assertHandleIntentionalError(TestContext ctx, String errMessage, Async latch) {
+    return throwable -> {
+      try {
+        assertIntentionalError(ctx, errMessage).accept(throwable);
+      } catch (Throwable e) {
+        ctx.fail(e);
+      }
+      latch.countDown();
+    };
   }
 
   @Before
   public void setUp() {
     db = mock.getClient();
-
   }
+
 }

--- a/src/test/java/com/noenv/wiremongo/mapping/MatchAllTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/MatchAllTest.java
@@ -2,9 +2,9 @@ package com.noenv.wiremongo.mapping;
 
 import com.noenv.wiremongo.TestBase;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.rxjava3.SingleHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -13,18 +13,13 @@ public class MatchAllTest extends TestBase {
 
   @Test
   public void testMatchAll(TestContext ctx) {
-    Async async = ctx.async();
-    Mapping m = mock.matchAll()
+    mock.matchAll()
       .stub(c -> {
         ctx.assertEquals("count", c.method());
         return 41L;
       });
 
     db.rxCount("count", new JsonObject().put("test", "testCount"))
-      .subscribe(s -> {
-        ctx.assertEquals(41L, s);
-        mock.removeMapping(m);
-        async.complete();
-      }, ctx::fail);
+      .subscribe(SingleHelper.toObserver(ctx.asyncAssertSuccess(s -> ctx.assertEquals(41L, s))));
   }
 }

--- a/src/test/java/com/noenv/wiremongo/mapping/ValidForTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/ValidForTest.java
@@ -2,7 +2,6 @@ package com.noenv.wiremongo.mapping;
 
 import com.noenv.wiremongo.TestBase;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.rxjava3.MaybeHelper;
@@ -20,8 +19,6 @@ public class ValidForTest extends TestBase {
 
   @Test
   public void testFindOneMultipleTimesWithoutTimes(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.findOne()
       .inCollection("findone")
       .withQuery(new JsonObject().put("test", "testFindOne"))
@@ -31,16 +28,11 @@ public class ValidForTest extends TestBase {
     db.rxFindOne("findone", new JsonObject().put("test", "testFindOne"), new JsonObject().put("field1", 1))
       .flatMap(x -> db.rxFindOne("findone", new JsonObject().put("test", "testFindOne"), new JsonObject().put("field1", 1)))
       .flatMap(x -> db.rxFindOne("findone", new JsonObject().put("test", "testFindOne"), new JsonObject().put("field1", 1)))
-      .subscribe(r -> {
-        ctx.assertEquals("value1", r.getString("field1"));
-        async.complete();
-      }, ctx::fail);
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r -> ctx.assertEquals("value1", r.getString("field1")))));
   }
 
   @Test
   public void testFindOneTimes(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.findOne()
       .inCollection("findone")
       .withQuery(new JsonObject().put("test", "testFindOne"))
@@ -51,10 +43,7 @@ public class ValidForTest extends TestBase {
     db.rxFindOne("findone", new JsonObject().put("test", "testFindOne"), new JsonObject().put("field1", 1))
       .flatMap(x -> db.rxFindOne("findone", new JsonObject().put("test", "testFindOne"), new JsonObject().put("field1", 1)))
       .flatMap(x -> db.rxFindOne("findone", new JsonObject().put("test", "testFindOne"), new JsonObject().put("field1", 1)))
-      .subscribe(r -> {
-        ctx.assertEquals("value1", r.getString("field1"));
-        async.complete();
-      }, ctx::fail);
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r -> ctx.assertEquals("value1", r.getString("field1")))));
   }
 
   @Test
@@ -69,6 +58,7 @@ public class ValidForTest extends TestBase {
     db.rxFindOne("findone", new JsonObject().put("test", "testFindOne"), new JsonObject().put("field1", 1))
       .flatMap(x -> db.rxFindOne("findone", new JsonObject().put("test", "testFindOne"), new JsonObject().put("field1", 1)))
       .flatMap(x -> db.rxFindOne("findone", new JsonObject().put("test", "testFindOne"), new JsonObject().put("field1", 1)))
+      .doOnError(assertNoMappingFoundError(ctx))
       .subscribe(MaybeHelper.toObserver(ctx.asyncAssertFailure()));
   }
 

--- a/src/test/java/com/noenv/wiremongo/mapping/aggregate/AggregateTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/aggregate/AggregateTest.java
@@ -41,10 +41,8 @@ public class AggregateTest extends TestBase {
       .returnsError(new Exception("intentional"));
 
     db.aggregate("aggregate", new JsonArray().add(new JsonObject().put("$match",new JsonObject().put("id","myIdError"))))
-      .exceptionHandler(ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
+      .handler(r -> ctx.fail("should fail"))
+      .exceptionHandler(assertHandleIntentionalError(ctx, "intentional", async));
   }
 
   @Test
@@ -54,23 +52,21 @@ public class AggregateTest extends TestBase {
       .handler(r -> {
         ctx.assertEquals("value1", r.getString("field1"));
         async.countDown();
-      });
+      }).exceptionHandler(ctx::fail);
   }
 
   @Test
+  @SuppressWarnings("java:S2699")
   public void testAggregateFileError(TestContext ctx) {
     Async async = ctx.async();
     db.aggregate("aggregate", new JsonArray().add(new JsonObject().put("test", "testAggregateFileError")))
-      .exceptionHandler(ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
+      .handler(r -> ctx.fail("should fail"))
+      .exceptionHandler(assertHandleIntentionalError(ctx, "intentional", async));
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void testAggregateReturnedObjectNotModified(TestContext ctx) {
-    final Async async = ctx.async(1 * 2);
+    final Async async = ctx.async(2);
     final JsonObject given = new JsonObject()
       .put("field1", "value1")
       .put("field2", "value2")
@@ -110,7 +106,6 @@ public class AggregateTest extends TestBase {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void testAggregateFileReturnedObjectNotModified(TestContext ctx) {
     final Async async = ctx.async(3 * 2);
     final JsonObject expected = new JsonObject().put("field1", "value1");

--- a/src/test/java/com/noenv/wiremongo/mapping/distinct/DistinctBatchWithQueryTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/distinct/DistinctBatchWithQueryTest.java
@@ -27,7 +27,7 @@ public class DistinctBatchWithQueryTest extends TestBase {
       .withResultClassname("io.vertx.core.json.JsonObject")
       .returns(MemoryStream.of(new JsonObject().put("x", "y")));
     db.distinctBatchWithQuery("distinctBatchWithQuery", "testDistinctBatchWithQuery",
-      "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar"))
+        "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar"))
       .handler(r -> {
         ctx.assertEquals("y", r.getString("x"));
         async.complete();
@@ -41,23 +41,20 @@ public class DistinctBatchWithQueryTest extends TestBase {
       .handler(r -> {
         ctx.assertEquals("value1", r.getString("field1"));
         async.countDown();
-      });
+      }).exceptionHandler(ctx::fail);
   }
 
   @Test
   public void testDistinctBatchWithQueryFileError(TestContext ctx) {
     Async async = ctx.async();
     db.distinctBatchWithQuery("distinctBatchWithQuery", "testDistinctBatchWithQueryFileError", "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar"))
-      .exceptionHandler(ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
+      .handler(r -> ctx.fail("should fail"))
+      .exceptionHandler(assertHandleIntentionalError(ctx, "intentional", async));
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void testDistinctBatchWithQueryReturnedObjectNotModified(TestContext ctx) {
-    final Async async = ctx.async(1 * 2);
+    final Async async = ctx.async(2);
     final JsonObject given = new JsonObject()
       .put("field1", "value1")
       .put("field2", "value2")
@@ -79,9 +76,9 @@ public class DistinctBatchWithQueryTest extends TestBase {
       .returns(MemoryStream.of(given));
 
     Flowable.mergeArray(
-      db.distinctBatchWithQuery("distinctBatchWithQuery", "testDistinctBatchWithQuery", "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar")).toFlowable(),
-      db.distinctBatchWithQuery("distinctBatchWithQuery", "testDistinctBatchWithQuery", "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar")).toFlowable()
-    )
+        db.distinctBatchWithQuery("distinctBatchWithQuery", "testDistinctBatchWithQuery", "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar")).toFlowable(),
+        db.distinctBatchWithQuery("distinctBatchWithQuery", "testDistinctBatchWithQuery", "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar")).toFlowable()
+      )
       .doOnNext(actual -> async.countDown())
       .doOnNext(actual -> ctx.assertEquals(expected, actual))
       .doOnNext(actual -> {
@@ -99,15 +96,14 @@ public class DistinctBatchWithQueryTest extends TestBase {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void testDistinctBatchWithQueryFileReturnedObjectNotModified(TestContext ctx) {
     final Async async = ctx.async(3 * 2);
     final JsonObject expected = new JsonObject().put("field1", "value1");
 
     Flowable.mergeArray(
-      db.distinctBatchWithQuery("distinctBatchWithQuery", "testDistinctBatchWithQueryFile", "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar")).toFlowable(),
-      db.distinctBatchWithQuery("distinctBatchWithQuery", "testDistinctBatchWithQueryFile", "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar")).toFlowable()
-    )
+        db.distinctBatchWithQuery("distinctBatchWithQuery", "testDistinctBatchWithQueryFile", "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar")).toFlowable(),
+        db.distinctBatchWithQuery("distinctBatchWithQuery", "testDistinctBatchWithQueryFile", "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar")).toFlowable()
+      )
       .doOnNext(actual -> async.countDown())
       .doOnNext(actual -> ctx.assertEquals(expected, actual))
       .doOnNext(actual -> {
@@ -123,12 +119,12 @@ public class DistinctBatchWithQueryTest extends TestBase {
     Async async = ctx.async();
     mock.distinctBatchWithQuery()
       .inCollection("testDistinctBatchWithQueryWithOptions")
-      .withFieldName("testDistinctBatchWithQuery")
+      .withFieldName("testDistinctBatchWithQueryWithOptions")
       .withQuery(new JsonObject().put("foo", "bar"))
       .withResultClassname("io.vertx.core.json.JsonObject")
       .withOptions(new DistinctOptions().setCollation(new CollationOptions().setLocale("no-way")))
       .returns(MemoryStream.of(new JsonObject().put("x", "y")));
-    db.distinctBatchWithQuery("testDistinctBatchWithQueryWithOptions", "testDistinctBatchWithQuery",
+    db.distinctBatchWithQuery("testDistinctBatchWithQueryWithOptions", "testDistinctBatchWithQueryWithOptions",
         "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar"), new DistinctOptions().setCollation(new CollationOptions().setLocale("no-way")))
       .handler(r -> {
         ctx.assertEquals("y", r.getString("x"));
@@ -137,8 +133,53 @@ public class DistinctBatchWithQueryTest extends TestBase {
   }
 
   @Test
-  public void testDistinctBatchWithQueryWithOptionsNoMatch(TestContext ctx) {
+  public void testDistinctBatchWithQueryWithOptionsFile(TestContext ctx) {
+    Async async = ctx.async(2);
+    db.distinctBatchWithQuery("testDistinctBatchWithQueryWithOptions", "testDistinctBatchWithQueryWithOptionsFile",
+        "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar"), new DistinctOptions().setCollation(new CollationOptions().setLocale("de_AT")))
+      .handler(r -> {
+        switch (async.count()) {
+          case 2:
+            ctx.assertEquals("value1", r.getString("field1"));
+            break;
+          case 1:
+            ctx.assertEquals("value2", r.getString("field2"));
+            break;
+          default:
+            ctx.fail("unexpected stream");
+            break;
+        }
+        async.countDown();
+      }).exceptionHandler(ctx::fail);
+  }
+
+  @Test
+  public void testDistinctBatchWithQueryWithOptionsError(TestContext ctx) {
     Async async = ctx.async();
+    mock.distinctBatchWithQuery()
+      .inCollection("testDistinctBatchWithQueryWithOptionsError")
+      .withFieldName("testDistinctBatchWithQueryWithOptionsError")
+      .withQuery(new JsonObject().put("foo", "bar"))
+      .withResultClassname("io.vertx.core.json.JsonObject")
+      .withOptions(new DistinctOptions().setCollation(new CollationOptions().setLocale("no-way")))
+      .returnsError(new Exception("intentional"));
+    db.distinctBatchWithQuery("testDistinctBatchWithQueryWithOptionsError", "testDistinctBatchWithQueryWithOptionsError",
+        "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar"), new DistinctOptions().setCollation(new CollationOptions().setLocale("no-way")))
+      .handler(r -> ctx.fail("should fail"))
+      .exceptionHandler(assertHandleIntentionalError(ctx, "intentional", async));
+  }
+
+  @Test
+  public void testDistinctBatchWithQueryWithOptionsFileError(TestContext ctx) {
+    Async async = ctx.async();
+    db.distinctBatchWithQuery("testDistinctBatchWithQueryWithOptionsError", "testDistinctBatchWithQueryWithOptionsFileError",
+        "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar"), new DistinctOptions().setCollation(new CollationOptions().setLocale("de_AT")))
+      .handler(r -> ctx.fail("should fail"))
+      .exceptionHandler(assertHandleIntentionalError(ctx, "intentional", async));
+  }
+
+  @Test
+  public void testDistinctBatchWithQueryWithOptionsNoMatch(TestContext ctx) {
     mock.distinctBatchWithQuery()
       .inCollection("testDistinctBatchWithQueryWithOptionsNoMatch")
       .withFieldName("testDistinctBatchWithQuery")
@@ -148,9 +189,45 @@ public class DistinctBatchWithQueryTest extends TestBase {
       .returns(MemoryStream.of(new JsonObject().put("x", "y")));
     db.distinctBatchWithQuery("testDistinctBatchWithQueryWithOptionsNoMatch", "testDistinctBatchWithQuery",
         "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar"), new DistinctOptions().setCollation(new CollationOptions().setLocale("no-way")))
+      .handler(r -> ctx.fail("should fail"))
+      .exceptionHandler(handleNoMappingFoundError(ctx));
+  }
+
+  @Test
+  public void testDistinctBatchWithQueryWithOptionsAndBatchSize(TestContext ctx) {
+    Async async = ctx.async();
+    mock.distinctBatchWithQuery()
+      .inCollection("testDistinctBatchWithQueryWithOptions")
+      .withFieldName("testDistinctBatchWithQuery")
+      .withQuery(new JsonObject().put("foo", "bar"))
+      .withBatchSize(25)
+      .withResultClassname("io.vertx.core.json.JsonObject")
+      .withOptions(new DistinctOptions().setCollation(new CollationOptions().setLocale("no-way")))
+      .returns(MemoryStream.of(new JsonObject().put("x", "y")));
+    db.distinctBatchWithQuery("testDistinctBatchWithQueryWithOptions", "testDistinctBatchWithQuery",
+        "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar"), 25, new DistinctOptions().setCollation(new CollationOptions().setLocale("no-way")))
       .handler(r -> {
-        ctx.fail("should fail");
-      }).exceptionHandler(e -> async.complete());
+        ctx.assertEquals("y", r.getString("x"));
+        async.complete();
+      }).exceptionHandler(ctx::fail);
+  }
+
+  @Test
+  public void testDistinctBatchWithQueryWithBatchSize(TestContext ctx) {
+    Async async = ctx.async();
+    mock.distinctBatchWithQuery()
+      .inCollection("testDistinctBatchWithQueryWithOptions")
+      .withFieldName("testDistinctBatchWithQuery")
+      .withQuery(new JsonObject().put("foo", "bar"))
+      .withBatchSize(25)
+      .withResultClassname("io.vertx.core.json.JsonObject")
+      .returns(MemoryStream.of(new JsonObject().put("x", "y")));
+    db.distinctBatchWithQuery("testDistinctBatchWithQueryWithOptions", "testDistinctBatchWithQuery",
+        "io.vertx.core.json.JsonObject", new JsonObject().put("foo", "bar"), 25)
+      .handler(r -> {
+        ctx.assertEquals("y", r.getString("x"));
+        async.complete();
+      }).exceptionHandler(ctx::fail);
   }
 
 }

--- a/src/test/java/com/noenv/wiremongo/mapping/distinct/DistinctTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/distinct/DistinctTest.java
@@ -2,13 +2,12 @@ package com.noenv.wiremongo.mapping.distinct;
 
 import com.noenv.wiremongo.TestBase;
 import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.CollationOptions;
 import io.vertx.ext.mongo.DistinctOptions;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.rxjava3.CompletableHelper;
+import io.vertx.rxjava3.SingleHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -17,43 +16,35 @@ public class DistinctTest extends TestBase {
 
   @Test
   public void testDistinct(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.distinct()
       .inCollection("distinct")
       .withFieldName("testDistinct")
       .returns(new JsonArray().add("A").add("B"));
 
     db.rxDistinct("distinct", "testDistinct", null)
-      .subscribe(r -> {
+      .subscribe(SingleHelper.toObserver(ctx.asyncAssertSuccess(r -> {
         ctx.assertEquals(2, r.size());
         ctx.assertEquals("A", r.getString(0));
         ctx.assertEquals("B", r.getString(1));
-        async.complete();
-      }, ctx::fail);
+      })));
   }
 
   @Test
   public void testDistinctFile(TestContext ctx) {
-    Async async = ctx.async();
     db.rxDistinct("distinct", "testDistinctFile", "java.lang.String")
-      .subscribe(r -> {
-        ctx.assertEquals(3, r.size());
-        ctx.assertEquals("A", r.getString(0));
-        ctx.assertEquals("B", r.getString(1));
-        ctx.assertEquals("C", r.getString(2));
-        async.complete();
-      }, ctx::fail);
+    .subscribe(SingleHelper.toObserver(ctx.asyncAssertSuccess(r -> {
+      ctx.assertEquals(3, r.size());
+      ctx.assertEquals("A", r.getString(0));
+      ctx.assertEquals("B", r.getString(1));
+      ctx.assertEquals("C", r.getString(2));
+    })));
   }
 
   @Test
   public void testDistinctFileError(TestContext ctx) {
-    Async async = ctx.async();
     db.rxDistinct("distinct", "testDistinctFileError", "java.lang.Integer")
-      .subscribe(r -> ctx.fail(), ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
+      .doOnError(assertIntentionalError(ctx, "intentional"))
+      .subscribe(SingleHelper.toObserver(ctx.asyncAssertFailure()));
   }
 
   @Test
@@ -94,43 +85,35 @@ public class DistinctTest extends TestBase {
 
   @Test
   public void testDistinctWithOptions(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.distinct()
       .inCollection("testDistinctWithOptions")
       .withFieldName("testDistinct")
       .withOptions(new DistinctOptions().setCollation(new CollationOptions().setLocale("no-way")))
       .returns(new JsonArray().add("A").add("B"));
 
-    db.distinct("testDistinctWithOptions", "testDistinct", null, result -> {
-      if(result.failed()) {
-        ctx.fail(result.cause());
-      } else {
-        JsonArray r = result.result();
+    db.distinct("testDistinctWithOptions", "testDistinct", null, new DistinctOptions().setCollation(new CollationOptions().setLocale("no-way")))
+      .subscribe(SingleHelper.toObserver(ctx.asyncAssertSuccess(r -> {
         ctx.assertEquals(2, r.size());
         ctx.assertEquals("A", r.getString(0));
         ctx.assertEquals("B", r.getString(1));
-        async.complete();
-      }
-    }, new DistinctOptions().setCollation(new CollationOptions().setLocale("no-way")));
+      })));
   }
 
   @Test
   public void testDistinctWithOptionsNoMatch(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.distinct()
       .inCollection("testDistinctWithOptionsNoMatch")
       .withFieldName("testDistinct")
-      .withOptions(new DistinctOptions().setCollation(new CollationOptions().setLocale("no-wy")))
-      .returns(new JsonArray().add("A").add("B"));
+      .withOptions(new DistinctOptions().setCollation(new CollationOptions().setLocale("no-way")))
+      .returns(new JsonArray());
 
-    db.distinct("testDistinctWithOptionsNoMatch", "testDistinct", null, result -> {
-      if(result.failed()) {
-        async.complete();
-      } else {
-        ctx.fail("should fail");
-      }
-    }, new DistinctOptions().setCollation(new CollationOptions().setLocale("no-way")));
+    db.distinct("testDistinctWithOptionsNoMatch", "testDistinct", null, new DistinctOptions().setCollation(new CollationOptions().setLocale("no-way")))
+      .subscribe(SingleHelper.toObserver(ctx.asyncAssertSuccess(r -> ctx.assertEquals(r, new JsonArray()))));
+  }
+
+  @Test
+  public void testDistinctFileWithOptionsNoMatch(TestContext ctx) {
+    db.distinct("testDistinctWithOptionsNoMatchFile", "testDistinctWithOptionsFile", null, new DistinctOptions().setCollation(new CollationOptions()))
+      .subscribe(SingleHelper.toObserver(ctx.asyncAssertSuccess(r -> ctx.assertEquals(r, new JsonArray()))));
   }
 }

--- a/src/test/java/com/noenv/wiremongo/mapping/find/FindOneAndDeleteTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/find/FindOneAndDeleteTest.java
@@ -3,10 +3,10 @@ package com.noenv.wiremongo.mapping.find;
 import com.noenv.wiremongo.TestBase;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.rxjava3.CompletableHelper;
+import io.vertx.rxjava3.MaybeHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -15,38 +15,30 @@ public class FindOneAndDeleteTest extends TestBase {
 
   @Test
   public void testFindOneAndDelete(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.findOneAndDelete()
       .inCollection("findOneAndDelete")
       .withQuery(new JsonObject().put("test", "testFindOneAndDelete"))
       .returns(new JsonObject().put("field1", "value1"));
 
     db.rxFindOneAndDelete("findOneAndDelete", new JsonObject().put("test", "testFindOneAndDelete"))
-      .subscribe(r -> {
-        ctx.assertEquals("value1", r.getString("field1"));
-        async.complete();
-      }, ctx::fail);
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r ->
+        ctx.assertEquals("value1", r.getString("field1"))
+      )));
   }
 
   @Test
   public void testFindOneAndDeleteFile(TestContext ctx) {
-    Async async = ctx.async();
     db.rxFindOneAndDelete("findOneAndDelete", new JsonObject().put("test", "testFindOneAndDeleteFile"))
-      .subscribe(r -> {
-        ctx.assertEquals("value1", r.getString("field1"));
-        async.complete();
-      }, ctx::fail);
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r ->
+        ctx.assertEquals("value1", r.getString("field1"))
+      )));
   }
 
   @Test
   public void testFindOneAndDeleteFileError(TestContext ctx) {
-    Async async = ctx.async();
     db.rxFindOneAndDelete("findOneAndDelete", new JsonObject().put("test", "testFindOneAndDeleteFileError"))
-      .subscribe(r -> ctx.fail(), ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
+      .doOnError(assertIntentionalError(ctx, "intentional"))
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertFailure()));
   }
 
   @Test

--- a/src/test/java/com/noenv/wiremongo/mapping/find/FindOneAndReplaceWithOptionsTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/find/FindOneAndReplaceWithOptionsTest.java
@@ -3,13 +3,14 @@ package com.noenv.wiremongo.mapping.find;
 import com.noenv.wiremongo.TestBase;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mongo.CollationOptions;
 import io.vertx.ext.mongo.FindOptions;
 import io.vertx.ext.mongo.UpdateOptions;
 import io.vertx.ext.mongo.WriteOption;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.rxjava3.CompletableHelper;
+import io.vertx.rxjava3.MaybeHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -18,53 +19,47 @@ public class FindOneAndReplaceWithOptionsTest extends TestBase {
 
   @Test
   public void testFindOneAndReplaceWithOptions(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.findOneAndReplaceWithOptions()
       .inCollection("findOneAndReplaceWithOptions")
       .withQuery(new JsonObject().put("test", "testFindOneAndReplaceWithOptions"))
       .withReplace(new JsonObject().put("foo", "bar"))
       .withFindOptions(new FindOptions().setLimit(4))
-      .withUpdateOptions(new UpdateOptions().setWriteOption(WriteOption.FSYNCED))
+      .withUpdateOptions(new UpdateOptions().setWriteOption(WriteOption.FSYNCED).setCollation(new CollationOptions().setLocale("de_AT").setStrength(1)))
       .returns(new JsonObject().put("field1", "value1"));
 
     db.rxFindOneAndReplaceWithOptions("findOneAndReplaceWithOptions",
-      new JsonObject().put("test", "testFindOneAndReplaceWithOptions"),
-      new JsonObject().put("foo", "bar"),
-      new FindOptions().setLimit(4),
-      new UpdateOptions().setWriteOption(WriteOption.FSYNCED))
-      .subscribe(r -> {
-        ctx.assertEquals("value1", r.getString("field1"));
-        async.complete();
-      }, ctx::fail);
+        new JsonObject().put("test", "testFindOneAndReplaceWithOptions"),
+        new JsonObject().put("foo", "bar"),
+        new FindOptions().setLimit(4),
+        new UpdateOptions().setWriteOption(WriteOption.FSYNCED).setCollation(new CollationOptions().setLocale("de_AT").setStrength(1))
+      )
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r ->
+        ctx.assertEquals("value1", r.getString("field1"))
+      )));
   }
 
   @Test
   public void testFindOneAndReplaceWithOptionsFile(TestContext ctx) {
-    Async async = ctx.async();
     db.rxFindOneAndReplaceWithOptions("findOneAndReplaceWithOptions",
-      new JsonObject().put("test", "testFindOneAndReplaceWithOptionsFile"),
-      new JsonObject().put("foo", "bar"),
-      new FindOptions().setFields(new JsonObject().put("field1", -1)),
-      new UpdateOptions().setReturningNewDocument(false))
-      .subscribe(r -> {
-        ctx.assertEquals("value1", r.getString("field1"));
-        async.complete();
-      }, ctx::fail);
+        new JsonObject().put("test", "testFindOneAndReplaceWithOptionsFile"),
+        new JsonObject().put("foo", "bar"),
+        new FindOptions().setFields(new JsonObject().put("field1", -1)),
+        new UpdateOptions().setReturningNewDocument(false)
+      )
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r ->
+        ctx.assertEquals("value1", r.getString("field1"))
+      )));
   }
 
   @Test
   public void testFindOneAndReplaceWithOptionsFileError(TestContext ctx) {
-    Async async = ctx.async();
     db.rxFindOneAndReplaceWithOptions("findOneAndReplaceWithOptions",
-      new JsonObject().put("test", "testFindOneAndReplaceWithOptionsFileError"),
-      new JsonObject().put("foo", "bar"),
-      new FindOptions().setLimit(42),
-      new UpdateOptions().setUpsert(true))
-      .subscribe(r -> ctx.fail(), ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
+        new JsonObject().put("test", "testFindOneAndReplaceWithOptionsFileError"),
+        new JsonObject().put("foo", "bar"),
+        new FindOptions().setLimit(42),
+        new UpdateOptions().setUpsert(true))
+      .doOnError(assertIntentionalError(ctx, "intentional"))
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertFailure()));
   }
 
   @Test
@@ -91,10 +86,10 @@ public class FindOneAndReplaceWithOptionsTest extends TestBase {
       .returns(given);
 
     db.rxFindOneAndReplaceWithOptions("findOneAndReplaceWithOptions",
-      new JsonObject().put("test", "testFindOneAndReplaceWithOptions"),
-      new JsonObject().put("foo", "bar"),
-      new FindOptions().setLimit(4),
-      new UpdateOptions().setWriteOption(WriteOption.FSYNCED))
+        new JsonObject().put("test", "testFindOneAndReplaceWithOptions"),
+        new JsonObject().put("foo", "bar"),
+        new FindOptions().setLimit(4),
+        new UpdateOptions().setWriteOption(WriteOption.FSYNCED))
       .doOnSuccess(actual -> ctx.assertEquals(expected, actual))
       .doOnSuccess(actual -> {
         actual.put("field1", "replace");
@@ -116,10 +111,10 @@ public class FindOneAndReplaceWithOptionsTest extends TestBase {
     final JsonObject expected = new JsonObject().put("field1", "value1");
 
     db.rxFindOneAndReplaceWithOptions("findOneAndReplaceWithOptions",
-      new JsonObject().put("test", "testFindOneAndReplaceWithOptionsFile"),
-      new JsonObject().put("foo", "bar"),
-      new FindOptions().setFields(new JsonObject().put("field1", -1)),
-      new UpdateOptions().setReturningNewDocument(false))
+        new JsonObject().put("test", "testFindOneAndReplaceWithOptionsFile"),
+        new JsonObject().put("foo", "bar"),
+        new FindOptions().setFields(new JsonObject().put("field1", -1)),
+        new UpdateOptions().setReturningNewDocument(false))
       .doOnSuccess(actual -> ctx.assertEquals(expected, actual))
       .doOnSuccess(actual -> {
         actual.put("field1", "replace");

--- a/src/test/java/com/noenv/wiremongo/mapping/find/FindOneAndUpdateTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/find/FindOneAndUpdateTest.java
@@ -3,23 +3,18 @@ package com.noenv.wiremongo.mapping.find;
 import com.noenv.wiremongo.TestBase;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.rxjava3.CompletableHelper;
+import io.vertx.rxjava3.MaybeHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.ArrayList;
-import java.util.Collections;
 
 @RunWith(VertxUnitRunner.class)
 public class FindOneAndUpdateTest extends TestBase {
 
   @Test
   public void testFindOneAndUpdate(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.findOneAndUpdate()
       .inCollection("findoneandupdate")
       .withQuery(new JsonObject().put("test", "testFindOneAndUpdate"))
@@ -27,30 +22,24 @@ public class FindOneAndUpdateTest extends TestBase {
       .returns(new JsonObject().put("field1", "value1"));
 
     db.rxFindOneAndUpdate("findoneandupdate", new JsonObject().put("test", "testFindOneAndUpdate"), new JsonObject().put("foo", "bar"))
-      .subscribe(r -> {
-        ctx.assertEquals("value1", r.getString("field1"));
-        async.complete();
-      }, ctx::fail);
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r ->
+        ctx.assertEquals("value1", r.getString("field1"))
+      )));
   }
 
   @Test
   public void testFindOneAndUpdateFile(TestContext ctx) {
-    Async async = ctx.async();
     db.rxFindOneAndUpdate("findoneandupdate", new JsonObject().put("test", "testFindOneAndUpdateFile"), new JsonObject().put("foo", "bar"))
-      .subscribe(r -> {
-        ctx.assertEquals("value1", r.getString("field1"));
-        async.complete();
-      }, ctx::fail);
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r ->
+        ctx.assertEquals("value1", r.getString("field1"))
+      )));
   }
 
   @Test
   public void testFindOneAndUpdateFileError(TestContext ctx) {
-    Async async = ctx.async();
     db.rxFindOneAndUpdate("findoneandupdate", new JsonObject().put("test", "testFindOneAndUpdateFileError"), new JsonObject().put("foo", "bar"))
-      .subscribe(r -> ctx.fail(), ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
+      .doOnError(assertIntentionalError(ctx, "intentional"))
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertFailure()));
   }
 
   @Test

--- a/src/test/java/com/noenv/wiremongo/mapping/find/FindOneTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/find/FindOneTest.java
@@ -3,23 +3,18 @@ package com.noenv.wiremongo.mapping.find;
 import com.noenv.wiremongo.TestBase;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.rxjava3.CompletableHelper;
+import io.vertx.rxjava3.MaybeHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.ArrayList;
-import java.util.Collections;
 
 @RunWith(VertxUnitRunner.class)
 public class FindOneTest extends TestBase {
 
   @Test
   public void testFindOne(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.findOne()
       .inCollection("findone")
       .withQuery(new JsonObject().put("test", "testFindOne"))
@@ -27,30 +22,20 @@ public class FindOneTest extends TestBase {
       .returns(new JsonObject().put("field1", "value1"));
 
     db.rxFindOne("findone", new JsonObject().put("test", "testFindOne"), new JsonObject().put("field1", 1))
-      .subscribe(r -> {
-        ctx.assertEquals("value1", r.getString("field1"));
-        async.complete();
-      }, ctx::fail);
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r -> ctx.assertEquals("value1", r.getString("field1")))));
   }
 
   @Test
   public void testFindOneFile(TestContext ctx) {
-    Async async = ctx.async();
     db.rxFindOne("findone", new JsonObject().put("test", "testFindOneFile"), new JsonObject().put("field1", 1))
-      .subscribe(r -> {
-        ctx.assertEquals("value1", r.getString("field1"));
-        async.complete();
-      }, ctx::fail);
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r -> ctx.assertEquals("value1", r.getString("field1")))));
   }
 
   @Test
   public void testFindOneFileError(TestContext ctx) {
-    Async async = ctx.async();
     db.rxFindOne("findone", new JsonObject().put("test", "testFindOneFileError"), null)
-      .subscribe(r -> ctx.fail(), ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
+      .doOnError(assertIntentionalError(ctx, "intentional"))
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertFailure()));
   }
 
   @Test

--- a/src/test/java/com/noenv/wiremongo/mapping/index/CreateIndexTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/index/CreateIndexTest.java
@@ -2,9 +2,9 @@ package com.noenv.wiremongo.mapping.index;
 
 import com.noenv.wiremongo.TestBase;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.rxjava3.CompletableHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -13,31 +13,25 @@ public class CreateIndexTest extends TestBase {
 
   @Test
   public void testCreateIndex(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.createIndex()
       .inCollection("createindex")
       .withKey(new JsonObject().put("test", "testCreateIndex"))
       .returns(null);
 
     db.rxCreateIndex("createindex", new JsonObject().put("test", "testCreateIndex"))
-      .subscribe(async::complete, ctx::fail);
+      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertSuccess()));
   }
 
   @Test
   public void testCreateIndexFile(TestContext ctx) {
-    Async async = ctx.async();
     db.rxCreateIndex("createindex", new JsonObject().put("test", "testCreateIndexFile"))
-      .subscribe(async::complete, ctx::fail);
+      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertSuccess()));
   }
 
   @Test
   public void testCreateIndexFileError(TestContext ctx) {
-    Async async = ctx.async();
     db.rxCreateIndex("createindex", new JsonObject().put("test", "testCreateIndexFileError"))
-      .subscribe(ctx::fail, ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
+      .doOnError(assertIntentionalError(ctx, "intentional"))
+      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertFailure()));
   }
 }

--- a/src/test/java/com/noenv/wiremongo/mapping/index/CreateIndexWithOptionsTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/index/CreateIndexWithOptionsTest.java
@@ -4,9 +4,9 @@ import com.noenv.wiremongo.TestBase;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.CollationOptions;
 import io.vertx.ext.mongo.IndexOptions;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.rxjava3.CompletableHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -14,9 +14,7 @@ import org.junit.runner.RunWith;
 public class CreateIndexWithOptionsTest extends TestBase {
 
   @Test
-  public void testCreateIndex(TestContext ctx) {
-    Async async = ctx.async();
-
+  public void testCreateIndexWithOptions(TestContext ctx) {
     mock.createIndexWithOptions()
       .inCollection("createindexwithoptions")
       .withOptions(new IndexOptions().background(false).unique(true).sparse(false))
@@ -24,34 +22,43 @@ public class CreateIndexWithOptionsTest extends TestBase {
       .returns(null);
 
     db.rxCreateIndexWithOptions("createindexwithoptions",
-      new JsonObject().put("test", "testCreateIndexWithOptions"),
-      new IndexOptions().background(false).unique(true).sparse(false))
-      .subscribe(async::complete, ctx::fail);
+        new JsonObject().put("test", "testCreateIndexWithOptions"),
+        new IndexOptions().background(false).unique(true).sparse(false))
+      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertSuccess()));
   }
 
   @Test
-  public void testCreateIndexFile(TestContext ctx) {
-    Async async = ctx.async();
-    db.rxCreateIndexWithOptions("createindexwithoptions", new JsonObject().put("test", "testCreateIndexWithOptionsFile"),
-      new IndexOptions().name("testIndex"))
-      .subscribe(async::complete, ctx::fail);
+  public void testCreateIndexWithOptionsAndCollationFile(TestContext ctx) {
+    db.rxCreateIndexWithOptions(
+        "createindexwithoptions",
+        new JsonObject().put("test", "testCreateIndexWithOptionsAndCollationFile"),
+        new IndexOptions().name("testIndex").setCollation(new CollationOptions())
+      )
+      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertSuccess()));
   }
 
   @Test
-  public void testCreateIndexFileError(TestContext ctx) {
-    Async async = ctx.async();
+  public void testCreateIndexWithOptionsFile(TestContext ctx) {
+    db.rxCreateIndexWithOptions(
+        "createindexwithoptions",
+        new JsonObject().put("test", "testCreateIndexWithOptionsFile"),
+        new IndexOptions().name("testIndex")
+      )
+      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertSuccess()));
+  }
+
+  @Test
+  public void testCreateIndexWithOptionsFileError(TestContext ctx) {
     db.rxCreateIndexWithOptions("createindexwithoptions", new JsonObject().put("test", "testCreateIndexWithOptionsFileError"),
-      new IndexOptions().background(false).unique(false).sparse(false).name("testIndexError"))
-      .subscribe(ctx::fail, ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
+        new IndexOptions().background(false).unique(false).sparse(false).name("testIndexError").setCollation(new CollationOptions().setLocale("de_AT"))
+      )
+      .doOnError(assertIntentionalError(ctx, "intentional"))
+      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertFailure()));
   }
 
 
   @Test
-  public void testCreateIndexWithCollation(TestContext ctx) {
-    Async async = ctx.async();
+  public void testCreateIndexWithOptionsWithCollation(TestContext ctx) {
     mock.createIndexWithOptions()
       .inCollection("createindexwithoptions")
       .withOptions(new IndexOptions().background(false).unique(true).sparse(false).setCollation(new CollationOptions().setLocale("no-way")))
@@ -61,23 +68,22 @@ public class CreateIndexWithOptionsTest extends TestBase {
     db.rxCreateIndexWithOptions("createindexwithoptions",
         new JsonObject().put("test", "testCreateIndexWithOptions"),
         new IndexOptions().background(false).unique(true).sparse(false).setCollation(new CollationOptions().setLocale("no-way")))
-      .subscribe(async::complete, ctx::fail);
+      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertSuccess()));
   }
 
   @Test
-  public void testCreateIndexWithCollationNoMatch(TestContext ctx) {
-    Async async = ctx.async();
-
+  public void testCreateIndexWithOptionsWithCollationNoMatch(TestContext ctx) {
     mock.createIndexWithOptions()
       .inCollection("createindexwithoptions")
-      .withOptions(new IndexOptions().background(false).unique(true).sparse(false).setCollation(new CollationOptions().setLocale("no-wy")))
+      .withOptions(new IndexOptions().background(false).unique(true).sparse(false).setCollation(new CollationOptions().setLocale("DIFFERENT")))
       .withKey(new JsonObject().put("test", "testCreateIndexWithOptions"))
       .returns(null);
 
     db.rxCreateIndexWithOptions("createindexwithoptions",
         new JsonObject().put("test", "testCreateIndexWithOptions"),
         new IndexOptions().background(false).unique(true).sparse(false).setCollation(new CollationOptions().setLocale("no-way")))
-      .subscribe(() -> ctx.fail("should not match"), e -> async.complete());
+      .doOnError(assertNoMappingFoundError(ctx))
+      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertFailure()));
   }
 
 }

--- a/src/test/java/com/noenv/wiremongo/mapping/index/CreateIndexesTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/index/CreateIndexesTest.java
@@ -4,54 +4,38 @@ import com.noenv.wiremongo.TestBase;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.IndexModel;
 import io.vertx.ext.mongo.IndexOptions;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.rxjava3.CompletableHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 @RunWith(VertxUnitRunner.class)
 public class CreateIndexesTest extends TestBase {
 
   @Test
   public void testCreateIndexes(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.createIndexes()
       .inCollection("createindexes")
-      .withIndexModels(Arrays.asList(new IndexModel(new JsonObject().put("test", "testCreateIndex"))))
+      .withIndexModels(Collections.singletonList(new IndexModel(new JsonObject().put("test", "testCreateIndex"))))
       .returns(null);
 
-    db.rxCreateIndexes("createindexes", Arrays.asList(new IndexModel(new JsonObject().put("test", "testCreateIndex"))))
-      .subscribe(async::complete, ctx::fail);
+    db.rxCreateIndexes("createindexes", Collections.singletonList(new IndexModel(new JsonObject().put("test", "testCreateIndex"))))
+      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertSuccess()));
   }
 
   @Test
   public void testCreateIndexesFile(TestContext ctx) {
-    Async async = ctx.async();
-    db.rxCreateIndexes("createindexes", Arrays.asList(new IndexModel(new JsonObject().put("foo", 1), new IndexOptions().name("testCreateIndexesFile"))))
-      .subscribe(async::complete, ctx::fail);
+    db.rxCreateIndexes("createindexes", Collections.singletonList(new IndexModel(new JsonObject().put("foo", 1), new IndexOptions().name("testCreateIndexesFile"))))
+      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertSuccess()));
   }
 
   @Test
   public void testCreateIndexesFileError(TestContext ctx) {
-    Async async = ctx.async();
-    db.rxCreateIndexes("createindexes", Arrays.asList(new IndexModel(new JsonObject().put("foo", 1), new IndexOptions().name("testCreateIndexesFileError"))))
-      .subscribe(ctx::fail, ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
-  }
-
-  @Test
-  public void testCreateIndexFileError(TestContext ctx) {
-    Async async = ctx.async();
-    db.rxCreateIndex("createindex", new JsonObject().put("test", "testCreateIndexFileError"))
-      .subscribe(ctx::fail, ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
+    db.rxCreateIndexes("createindexes", Collections.singletonList(new IndexModel(new JsonObject().put("foo", 1), new IndexOptions().name("testCreateIndexesFileError"))))
+      .doOnError(assertIntentionalError(ctx, "intentional"))
+      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertFailure()));
   }
 }

--- a/src/test/java/com/noenv/wiremongo/mapping/index/ListIndexesTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/index/ListIndexesTest.java
@@ -6,13 +6,9 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.rxjava3.CompletableHelper;
-import io.vertx.rxjava3.MaybeHelper;
 import io.vertx.rxjava3.SingleHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.ArrayList;
-import java.util.Collections;
 
 @RunWith(VertxUnitRunner.class)
 public class ListIndexesTest extends TestBase {

--- a/src/test/java/com/noenv/wiremongo/mapping/remove/RemoveDocumentsTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/remove/RemoveDocumentsTest.java
@@ -3,9 +3,9 @@ package com.noenv.wiremongo.mapping.remove;
 import com.noenv.wiremongo.TestBase;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.MongoClientDeleteResult;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.rxjava3.MaybeHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -14,37 +14,29 @@ public class RemoveDocumentsTest extends TestBase {
 
   @Test
   public void testRemoveDocuments(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.removeDocuments()
       .inCollection("removeDocuments")
       .withQuery(new JsonObject().put("test", "testRemoveDocuments"))
       .returns(new MongoClientDeleteResult(1));
 
     db.rxRemoveDocuments("removeDocuments", new JsonObject().put("test", "testRemoveDocuments"))
-      .subscribe(r -> {
-        ctx.assertEquals(1L, r.getRemovedCount());
-        async.complete();
-      }, ctx::fail);
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r ->
+        ctx.assertEquals(1L, r.getRemovedCount())
+      )));
   }
 
   @Test
   public void testRemoveDocumentsFile(TestContext ctx) {
-    Async async = ctx.async();
     db.rxRemoveDocuments("removeDocuments", new JsonObject().put("test", "testRemoveDocumentsFile"))
-      .subscribe(r -> {
-        ctx.assertEquals(2L, r.getRemovedCount());
-        async.complete();
-      }, ctx::fail);
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r ->
+        ctx.assertEquals(2L, r.getRemovedCount())
+      )));
   }
 
   @Test
   public void testRemoveDocumentsFileError(TestContext ctx) {
-    Async async = ctx.async();
     db.rxRemoveDocuments("removeDocuments", new JsonObject().put("test", "testRemoveDocumentsFileError"))
-      .subscribe(r -> ctx.fail(), ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
+      .doOnError(assertIntentionalError(ctx, "intentional"))
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertFailure()));
   }
 }

--- a/src/test/java/com/noenv/wiremongo/mapping/update/UpdateCollectionTest.java
+++ b/src/test/java/com/noenv/wiremongo/mapping/update/UpdateCollectionTest.java
@@ -5,10 +5,10 @@ import com.noenv.wiremongo.TestBase;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mongo.MongoClientUpdateResult;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.rxjava3.CompletableHelper;
+import io.vertx.rxjava3.MaybeHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -17,8 +17,6 @@ public class UpdateCollectionTest extends TestBase {
 
   @Test
   public void testUpdateCollection(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.updateCollection()
       .inCollection("updatecollection")
       .withQuery(new JsonObject().put("test", "testUpdateCollection"))
@@ -26,32 +24,26 @@ public class UpdateCollectionTest extends TestBase {
       .returns(new MongoClientUpdateResult(37, null, 21));
 
     db.rxUpdateCollection("updatecollection", new JsonObject().put("test", "testUpdateCollection"), new JsonObject().put("foo", "bar"))
-      .subscribe(r -> {
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r -> {
         ctx.assertEquals(37L, r.getDocMatched());
         ctx.assertEquals(21L, r.getDocModified());
-        async.complete();
-      }, ctx::fail);
+      })));
   }
 
   @Test
   public void testUpdateCollectionFile(TestContext ctx) {
-    Async async = ctx.async();
     db.rxUpdateCollection("updatecollection", new JsonObject().put("test", "testUpdateCollectionFile"), new JsonObject().put("foo", "bar"))
-      .subscribe(r -> {
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r -> {
         ctx.assertEquals(42L, r.getDocMatched());
         ctx.assertEquals(11L, r.getDocModified());
-        async.complete();
-      }, ctx::fail);
+      })));
   }
 
   @Test
   public void testUpdateCollectionFileError(TestContext ctx) {
-    Async async = ctx.async();
     db.rxUpdateCollection("updatecollection", new JsonObject().put("test", "testUpdateCollectionFileError"), new JsonObject().put("foo", "bar"))
-      .subscribe(r -> ctx.fail(), ex -> {
-        ctx.assertEquals("intentional", ex.getMessage());
-        async.complete();
-      });
+      .doOnError(assertIntentionalError(ctx, "intentional"))
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertFailure()));
   }
 
   @Test
@@ -109,8 +101,6 @@ public class UpdateCollectionTest extends TestBase {
 
   @Test
   public void testUpdateCollectionAggregationPipeline(TestContext ctx) {
-    Async async = ctx.async();
-
     mock.updateCollectionAggregationPipeline()
       .inCollection("updatecollection")
       .withQuery(new JsonObject().put("test", "testUpdateCollection"))
@@ -118,24 +108,21 @@ public class UpdateCollectionTest extends TestBase {
       .returns(new MongoClientUpdateResult(37, null, 21));
 
     db.rxUpdateCollection("updatecollection", new JsonObject().put("test", "testUpdateCollection"), new JsonArray().add(new JsonObject().put("foo", "bar")))
-      .subscribe(r -> {
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r -> {
         ctx.assertEquals(37L, r.getDocMatched());
         ctx.assertEquals(21L, r.getDocModified());
-        async.complete();
-      }, ctx::fail);
+      })));
   }
 
   @Test
   public void testUpdateCollectionAggregationPipelineFile(TestContext ctx) {
-    Async async = ctx.async();
     db.rxUpdateCollection("updatecollection",
-      new JsonObject().put("test", "testUpdateCollectionAggregationPipelineFile"),
-      new JsonArray().add(new JsonObject().put("foo", "bar")))
-      .subscribe(r -> {
+        new JsonObject().put("test", "testUpdateCollectionAggregationPipelineFile"),
+        new JsonArray().add(new JsonObject().put("foo", "bar")))
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertSuccess(r -> {
         ctx.assertEquals(42L, r.getDocMatched());
         ctx.assertEquals(11L, r.getDocModified());
-        async.complete();
-      }, ctx::fail);
+      })));
   }
 
   @Test
@@ -149,14 +136,11 @@ public class UpdateCollectionTest extends TestBase {
     db.rxUpdateCollection("updatecollection",
         new JsonObject().put("test", "testUpdateCollection"),
         new JsonObject().put("foo", "bar"))
-      .doOnError(cause -> {
-        ctx.assertTrue(cause instanceof MongoCommandException);
-        final MongoCommandException actual = (MongoCommandException) cause;
-        ctx.assertEquals("E11000 duplicate key error", actual.getErrorMessage());
-        ctx.assertEquals(11000, actual.getErrorCode());
-        ctx.assertEquals("DuplicateKey", actual.getErrorCodeName());
-      })
-      .ignoreElement()
-      .subscribe(CompletableHelper.toObserver(ctx.asyncAssertFailure()));
+      .doOnError(assertMongoException(ctx, MongoCommandException.class, mce -> {
+        ctx.assertEquals("E11000 duplicate key error", mce.getErrorMessage());
+        ctx.assertEquals(11000, mce.getErrorCode());
+        ctx.assertEquals("DuplicateKey", mce.getErrorCodeName());
+      }))
+      .subscribe(MaybeHelper.toObserver(ctx.asyncAssertFailure()));
   }
 }

--- a/src/test/resources/wiremongo-mocks/count/countWithOptions.json
+++ b/src/test/resources/wiremongo-mocks/count/countWithOptions.json
@@ -11,19 +11,7 @@
   "options": {
     "equalTo": {
       "collation": {
-        "alternate": null,
-        "backwards": false,
-        "caseFirst": "off",
-        "caseLevel": false,
-        "locale": "de_AT",
-        "maxVariable": "punct",
-        "normalization": false,
-        "numericOrdering": false,
-        "strength": 3
-      },
-      "limit": 0,
-      "maxTime": 0,
-      "skip": 0
+      }
     }
   },
   "response": 26

--- a/src/test/resources/wiremongo-mocks/count/countWithOptionsError.json
+++ b/src/test/resources/wiremongo-mocks/count/countWithOptionsError.json
@@ -11,19 +11,8 @@
   "options": {
     "equalTo": {
       "collation": {
-        "alternate": null,
-        "backwards": false,
-        "caseFirst": "off",
-        "caseLevel": false,
-        "locale": "de_AT",
-        "maxVariable": "punct",
-        "normalization": false,
-        "numericOrdering": false,
-        "strength": 3
-      },
-      "limit": 0,
-      "maxTime": 0,
-      "skip": 0
+        "locale": "de_AT"
+      }
     }
   },
   "error": {

--- a/src/test/resources/wiremongo-mocks/createcollection/createCollectionWithOptions.json
+++ b/src/test/resources/wiremongo-mocks/createcollection/createCollectionWithOptions.json
@@ -5,16 +5,6 @@
   },
   "options": {
     "equalTo": {
-      "capped": false,
-      "indexOptionDefaults": {},
-      "maxDocuments": 0,
-      "sizeInBytes": 0,
-      "storageEngineOptions": {},
-      "validationOptions": {
-        "validationAction": "ERROR",
-        "validationLevel": "STRICT",
-        "validator": {}
-      }
     }
   },
   "response": null

--- a/src/test/resources/wiremongo-mocks/createcollection/createCollectionWithOptionsError.json
+++ b/src/test/resources/wiremongo-mocks/createcollection/createCollectionWithOptionsError.json
@@ -5,16 +5,6 @@
   },
   "options": {
     "equalTo": {
-      "capped": false,
-      "indexOptionDefaults": {},
-      "maxDocuments": 0,
-      "sizeInBytes": 0,
-      "storageEngineOptions": {},
-      "validationOptions": {
-        "validationAction": "ERROR",
-        "validationLevel": "STRICT",
-        "validator": {}
-      }
     }
   },
   "error": {

--- a/src/test/resources/wiremongo-mocks/createindex/createIndexWithOptionsAndCollation.json
+++ b/src/test/resources/wiremongo-mocks/createindex/createIndexWithOptionsAndCollation.json
@@ -5,12 +5,13 @@
   },
   "key": {
     "equalTo": {
-      "test": "testCreateIndexWithOptionsFile"
+      "test": "testCreateIndexWithOptionsAndCollationFile"
     }
   },
   "options": {
     "equalTo": {
-      "name": "testIndex"
+      "name": "testIndex",
+      "collation": {}
     }
   },
   "response": null

--- a/src/test/resources/wiremongo-mocks/createindex/createIndexWithOptionsError.json
+++ b/src/test/resources/wiremongo-mocks/createindex/createIndexWithOptionsError.json
@@ -14,7 +14,9 @@
       "unique": false,
       "sparse": false,
       "name": "testIndexError",
-      "collation": {}
+      "collation": {
+        "locale": "de_AT"
+      }
     }
   },
   "error": {

--- a/src/test/resources/wiremongo-mocks/createindex/createIndexes.json
+++ b/src/test/resources/wiremongo-mocks/createindex/createIndexes.json
@@ -10,8 +10,7 @@
           "foo": 1
         },
         "options": {
-          "name": "testCreateIndexesFile",
-          "collation": {}
+          "name": "testCreateIndexesFile"
         }
       }
     ]

--- a/src/test/resources/wiremongo-mocks/createindex/createIndexesError.json
+++ b/src/test/resources/wiremongo-mocks/createindex/createIndexesError.json
@@ -10,8 +10,7 @@
           "foo": 1
         },
         "options": {
-          "name": "testCreateIndexesFileError",
-          "collation": {}
+          "name": "testCreateIndexesFileError"
         }
       }
     ]

--- a/src/test/resources/wiremongo-mocks/distinct/distinctBatchWithOptions.json
+++ b/src/test/resources/wiremongo-mocks/distinct/distinctBatchWithOptions.json
@@ -1,0 +1,27 @@
+{
+  "method": "distinctBatch",
+  "collection": {
+    "equalTo": "testDistinctBatchWithOptions"
+  },
+  "fieldName": {
+    "equalTo": "testDistinctBatchWithOptionsFile"
+  },
+  "resultClassname": {
+    "equalTo": "io.vertx.core.json.JsonObject"
+  },
+  "options": {
+    "equalTo": {
+      "collation": {
+        "locale": "de_AT"
+      }
+    }
+  },
+  "response": [
+    {
+      "field1": "value1"
+    },
+    {
+      "field2": "value2"
+    }
+  ]
+}

--- a/src/test/resources/wiremongo-mocks/distinct/distinctBatchWithOptionsError.json
+++ b/src/test/resources/wiremongo-mocks/distinct/distinctBatchWithOptionsError.json
@@ -1,0 +1,22 @@
+{
+  "method": "distinctBatch",
+  "collection": {
+    "equalTo": "testDistinctBatchWithOptionsFileError"
+  },
+  "fieldName": {
+    "equalTo": "testDistinctBatchWithOptionsFileError"
+  },
+  "resultClassname": {
+    "equalTo": "io.vertx.core.json.JsonObject"
+  },
+  "options": {
+    "equalTo": {
+      "collation": {
+        "locale": "de_AT"
+      }
+    }
+  },
+  "error": {
+    "message": "intentional"
+  }
+}

--- a/src/test/resources/wiremongo-mocks/distinct/distinctBatchWithQueryWithOptions.json
+++ b/src/test/resources/wiremongo-mocks/distinct/distinctBatchWithQueryWithOptions.json
@@ -1,0 +1,33 @@
+{
+  "method": "distinctBatchWithQuery",
+  "collection": {
+    "equalTo": "testDistinctBatchWithQueryWithOptions"
+  },
+  "fieldName": {
+    "equalTo": "testDistinctBatchWithQueryWithOptionsFile"
+  },
+  "resultClassname": {
+    "equalTo": "io.vertx.core.json.JsonObject"
+  },
+
+  "query": {
+    "equalTo": {
+      "foo": "bar"
+    }
+  },
+  "options": {
+    "equalTo": {
+      "collation": {
+        "locale": "de_AT"
+      }
+    }
+  },
+  "response": [
+    {
+      "field1": "value1"
+    },
+    {
+      "field2": "value2"
+    }
+  ]
+}

--- a/src/test/resources/wiremongo-mocks/distinct/distinctBatchWithQueryWithOptionsError.json
+++ b/src/test/resources/wiremongo-mocks/distinct/distinctBatchWithQueryWithOptionsError.json
@@ -1,0 +1,28 @@
+{
+  "method": "distinctBatchWithQuery",
+  "collection": {
+    "equalTo": "testDistinctBatchWithQueryWithOptionsError"
+  },
+  "fieldName": {
+    "equalTo": "testDistinctBatchWithQueryWithOptionsFileError"
+  },
+  "resultClassname": {
+    "equalTo": "io.vertx.core.json.JsonObject"
+  },
+
+  "query": {
+    "equalTo": {
+      "foo": "bar"
+    }
+  },
+  "options": {
+    "equalTo": {
+      "collation": {
+        "locale": "de_AT"
+      }
+    }
+  },
+  "error": {
+      "message": "intentional"
+    }
+}

--- a/src/test/resources/wiremongo-mocks/distinct/distinctWithOptions.json
+++ b/src/test/resources/wiremongo-mocks/distinct/distinctWithOptions.json
@@ -1,0 +1,15 @@
+{
+  "method": "distinct",
+  "collection": {
+    "equalTo": "testDistinctWithOptionsNoMatchFile"
+  },
+  "fieldName": {
+    "equalTo": "testDistinctWithOptionsFile"
+  },
+  "options": {
+    "equalTo": {
+      "collation": {}
+    }
+  },
+  "response": []
+}

--- a/src/test/resources/wiremongo-mocks/distinct/distinctWithQueryWithOptions.json
+++ b/src/test/resources/wiremongo-mocks/distinct/distinctWithQueryWithOptions.json
@@ -1,0 +1,25 @@
+{
+  "method": "distinctWithQuery",
+  "collection": {
+    "equalTo": "distinctWithQueryWithOptions"
+  },
+  "fieldName": {
+    "equalTo": "testDistinctWithQueryWithOptionsFile"
+  },
+  "resultClassname": {
+    "equalTo": "java.lang.String"
+  },
+  "query": {
+    "equalTo": {
+      "foo": "bar"
+    }
+  },
+  "options": {
+    "equalTo": {
+      "collation": {
+        "locale": "no-way"
+      }
+    }
+  },
+  "response": ["A", "B", "C"]
+}

--- a/src/test/resources/wiremongo-mocks/distinct/distinctWithQueryWithOptionsError.json
+++ b/src/test/resources/wiremongo-mocks/distinct/distinctWithQueryWithOptionsError.json
@@ -1,0 +1,27 @@
+{
+  "method": "distinctWithQuery",
+  "collection": {
+    "equalTo": "distinctWithQueryWithOptions"
+  },
+  "fieldName": {
+    "equalTo": "testDistinctWithQueryWithOptionsFileError"
+  },
+  "resultClassname": {
+    "equalTo": "java.lang.String"
+  },
+  "query": {
+    "equalTo": {
+      "foo": "bar"
+    }
+  },
+  "options": {
+    "equalTo": {
+      "collation": {
+        "locale": "no-way"
+      }
+    }
+  },
+  "error": {
+    "message": "intentional"
+  }
+}


### PR DESCRIPTION
Change MongoClient contract (to rx-fiable version) of distinct (cleanup of 4.2.3)
Refactor tests from 4.2.3 using a fully initialized CollationOptions object
Add exceptionHandler/handler to various batch tests to quickly failing test context on bad behaviour
Cleanup imports
Refactor/review tests and use RxHelper methods for assertion instead of async latches (if applicable)
Refactor error assertions into TestBase static methods
Add additional tests for DistinctBatchWithQuery
Fix minor linter issuers in FindBase
Change index tests, due to default IndexOptions now  implicitly set by mongo client

Signed-off-by: Christoph Spörk <christoph.spoerk@gmail.com>