### PR TITLE
NPE in MemoryStream

### DIFF
--- a/src/main/java/com/noenv/wiremongo/MemoryStream.java
+++ b/src/main/java/com/noenv/wiremongo/MemoryStream.java
@@ -76,7 +76,7 @@ public class MemoryStream<T> implements ReadStream<T> {
   @Override
   public ReadStream<T> endHandler(@Nullable Handler<Void> endHandler) {
     this.endHandler = endHandler;
-    if (this.items.isEmpty()) {
+    if (this.items.isEmpty() && endHandler != null) {
       endHandler.handle(null);
     }
     return this;


### PR DESCRIPTION
`MemoryStream` throws a NPE when `endHandler` is not set but this happens e.g. when using `.toObservable()`.